### PR TITLE
docs: add missing redirects to audit reports in README

### DIFF
--- a/acre/README.md
+++ b/acre/README.md
@@ -2,12 +2,13 @@
 
 ## Reports by Severity
 
+[Medium](<README.md#medium>) | [Low](<README.md#low>) | [Insight](<README.md#insight>)
 <details>
 
 <summary>Medium</summary>
 
-* \#34836 \[SC-Medium] Malicious party can make it impossible for debt to be completely repaid by donating a few tbtc to \`stBTC.sol\`
-* \#34712 \[SC-Medium] Malicious users can block repay debt transactions with no cost
+* [34836 - [SC - Medium] Malicious party can make it impossible for debt to be completely repaid by donating a few tbtc to \`stBTC.sol\`](./34836-sc-medium-malicious-party-can-make-it-impossible-for-debt-to-be-completely-repaid-by-donating.md)
+* [34712 - [SC - Medium] Malicious users can block repay debt transactions with no cost](./34712-sc-medium-malicious-users-can-block-repay-debt-transactions-with-no-cost.md)
 
 </details>
 
@@ -15,16 +16,16 @@
 
 <summary>Low</summary>
 
-* \#34851 \[SC-Low] Adversary can freeze users' fund in stBTC using donation attack on MezoAllocator
-* \#34729 \[SC-Low] \`releaseDeposit\` will likely fail, putting funds in MezoAllocator at risk of being permanently stuck
-* \#34748 \[SC-Low] Last withdrawer can be prevented from withdrawing their assets
-* \#34999 \[SC-Low] The tBTC in the MezoAllocator itself is not considered in the withdrawal function
-* \#34672 \[SC-Low] Protocol runs insolvent due to incorrect reliance on depositBalance which doesn't match holder balances
-* \#34995 \[SC-Low] \`mintDebt()\` and \`repayDebt()\` should return \`assets\` and not \`shares\`
-* \#35026 \[SC-Low] \`repayDebt\` in stbtc returns a worng value
-* \#35014 \[SC-Low] Incorrect rounding in mintDebt function might allow minimal shares dilution
-* \#34978 \[SC-Low] Protocol runs insolvent due to incorrect reliance on depositBalance which doesn't match holder balances
-* \#34959 \[SC-Low] \`mintDebt\` returns a wrong value
+* [34851 - [SC - Low] Adversary can freeze users' fund in stBTC using donation attack on MezoAllocator](./34851-sc-low-adversary-can-freeze-users-fund-in-stbtc-using-donation-attack-on-mezoallocator.md)
+* [34729 - [SC - Low] \`releaseDeposit\` will likely fail, putting funds in MezoAllocator at risk of being permanently stuck](./34729-sc-low-releasedeposit-will-likely-fail-putting-funds-in-mezoallocator-at-risk-of-being-permane.md)
+* [34748 - [SC - Low] Last withdrawer can be prevented from withdrawing their assets](./34748-sc-low-last-withdrawer-can-be-prevented-from-withdrawing-their-assets.md)
+* [34999 - [SC - Low] The tBTC in the MezoAllocator itself is not considered in the withdrawal function](./34999-sc-low-the-tbtc-in-the-mezoallocator-itself-is-not-considered-in-the-withdrawal-function.md)
+* [34672 - [SC - Low] Protocol runs insolvent due to incorrect reliance on depositBalance which doesn't match holder balances](./34672-sc-low-protocol-runs-insolvent-due-to-incorrect-reliance-on-depositbalance-which-doesnt-match.md)
+* [34995 - [SC - Low] \`mintDebt()\` and \`repayDebt()\` should return \`assets\` and not \`shares\`](./34995-sc-low-mintdebt-and-repaydebt-should-return-assets-and-not-shares.md)
+* [35026 - [SC - Low] \`repayDebt\` in stbtc returns a worng value](./35026-sc-low-repaydebt-in-stbtc-returns-a-worng-value.md)
+* [35014 - [SC - Low] Incorrect rounding in mintDebt function might allow minimal shares dilution](./35014-sc-low-incorrect-rounding-in-mintdebt-function-might-allow-minimal-shares-dilution.md)
+* [34978 - [SC - Low] Protocol runs insolvent due to incorrect reliance on depositBalance which doesn't match holder balances](./34978-sc-low-protocol-runs-insolvent-due-to-incorrect-reliance-on-depositbalance-which-doesn-t-match.md)
+* [34959 - [SC - Low] \`mintDebt\` returns a wrong value](./34959-sc-low-mintdebt-returns-a-wrong-value.md)
 
 </details>
 
@@ -32,28 +33,29 @@
 
 <summary>Insight</summary>
 
-* \#34998 \[SC-Insight] Deposited assets in an old dispatcher may be lost when swapping to a new dispatcher
+* [34998 - [SC - Insight] Deposited assets in an old dispatcher may be lost when swapping to a new dispatcher](./34998-sc-insight-deposited-assets-in-an-old-dispatcher-may-be-lost-when-swapping-to-a-new-dispatcher.md)
 
 </details>
 
 ## Reports by Type
 
+[Smart Contract](<README.md#smart-contract>)
 <details>
 
 <summary>Smart Contract</summary>
 
-* \#34836 \[SC-Medium] Malicious party can make it impossible for debt to be completely repaid by donating a few tbtc to \`stBTC.sol\`
-* \#34851 \[SC-Low] Adversary can freeze users' fund in stBTC using donation attack on MezoAllocator
-* \#34729 \[SC-Low] \`releaseDeposit\` will likely fail, putting funds in MezoAllocator at risk of being permanently stuck
-* \#34748 \[SC-Low] Last withdrawer can be prevented from withdrawing their assets
-* \#34999 \[SC-Low] The tBTC in the MezoAllocator itself is not considered in the withdrawal function
-* \#34672 \[SC-Low] Protocol runs insolvent due to incorrect reliance on depositBalance which doesn't match holder balances
-* \#34998 \[SC-Insight] Deposited assets in an old dispatcher may be lost when swapping to a new dispatcher
-* \#34712 \[SC-Medium] Malicious users can block repay debt transactions with no cost
-* \#34995 \[SC-Low] \`mintDebt()\` and \`repayDebt()\` should return \`assets\` and not \`shares\`
-* \#35026 \[SC-Low] \`repayDebt\` in stbtc returns a worng value
-* \#35014 \[SC-Low] Incorrect rounding in mintDebt function might allow minimal shares dilution
-* \#34978 \[SC-Low] Protocol runs insolvent due to incorrect reliance on depositBalance which doesn't match holder balances
-* \#34959 \[SC-Low] \`mintDebt\` returns a wrong value
+* [34836 - [SC - Medium] Malicious party can make it impossible for debt to be completely repaid by donating a few tbtc to \`stBTC.sol\`](./34836-sc-medium-malicious-party-can-make-it-impossible-for-debt-to-be-completely-repaid-by-donating.md)
+* [34851 - [SC - Low] Adversary can freeze users' fund in stBTC using donation attack on MezoAllocator](./34851-sc-low-adversary-can-freeze-users-fund-in-stbtc-using-donation-attack-on-mezoallocator.md)
+* [34729 - [SC - Low] \`releaseDeposit\` will likely fail, putting funds in MezoAllocator at risk of being permanently stuck](./34729-sc-low-releasedeposit-will-likely-fail-putting-funds-in-mezoallocator-at-risk-of-being-permane.md)
+* [34748 - [SC - Low] Last withdrawer can be prevented from withdrawing their assets](./34748-sc-low-last-withdrawer-can-be-prevented-from-withdrawing-their-assets.md)
+* [34999 - [SC - Low] The tBTC in the MezoAllocator itself is not considered in the withdrawal function](./34999-sc-low-the-tbtc-in-the-mezoallocator-itself-is-not-considered-in-the-withdrawal-function.md)
+* [34672 - [SC - Low] Protocol runs insolvent due to incorrect reliance on depositBalance which doesn't match holder balances](./34672-sc-low-protocol-runs-insolvent-due-to-incorrect-reliance-on-depositbalance-which-doesnt-match.md)
+* [34998 - [SC - Insight] Deposited assets in an old dispatcher may be lost when swapping to a new dispatcher](./34998-sc-insight-deposited-assets-in-an-old-dispatcher-may-be-lost-when-swapping-to-a-new-dispatcher.md)
+* [34712 - [SC - Medium] Malicious users can block repay debt transactions with no cost](./34712-sc-medium-malicious-users-can-block-repay-debt-transactions-with-no-cost.md)
+* [34995 - [SC - Low] \`mintDebt()\` and \`repayDebt()\` should return \`assets\` and not \`shares\`](./34995-sc-low-mintdebt-and-repaydebt-should-return-assets-and-not-shares.md)
+* [35026 - [SC - Low] \`repayDebt\` in stbtc returns a worng value](./35026-sc-low-repaydebt-in-stbtc-returns-a-worng-value.md)
+* [35014 - [SC - Low] Incorrect rounding in mintDebt function might allow minimal shares dilution](./35014-sc-low-incorrect-rounding-in-mintdebt-function-might-allow-minimal-shares-dilution.md)
+* [34978 - [SC - Low] Protocol runs insolvent due to incorrect reliance on depositBalance which doesn't match holder balances](./34978-sc-low-protocol-runs-insolvent-due-to-incorrect-reliance-on-depositbalance-which-doesn-t-match.md)
+* [34959 - [SC - Low] \`mintDebt\` returns a wrong value](./34959-sc-low-mintdebt-returns-a-wrong-value.md)
 
 </details>

--- a/anvil-letters-of-credit/README.md
+++ b/anvil-letters-of-credit/README.md
@@ -2,13 +2,14 @@
 
 ## Reports by Severity
 
+[Critical](<README.md#critical>) | [Insight](<README.md#insight>)
 <details>
 
 <summary>Critical</summary>
 
-* \#36931 \[SC-Critical] Creators can modifyLOCCollateral of dynamic LOC to release almost all the collateral of LOC
-* \#36910 \[SC-Critical] LoC: The creator can withdraw the entire collateral of a Dynamic LoC making it insolvent
-* \#36807 \[SC-Critical] Attackers can create dynamic LOC with any credited amount with very small collateral amount
+* [36931 - [SC-Critical] Creators can modifyLOCCollateral of dynamic LOC to release almost all the collateral of LOC](./36931-sc-critical-critical-creators-can-modifyloccollateral-of-dynamic-loc-to-release-.....md)
+* [36910 - [SC-Critical] LoC: The creator can withdraw the entire collateral of a Dynamic LoC making it insolvent](./36910-sc-critical-loc-the-creator-can-withdraw-the-entire-collateral-of-a-dynamic-loc-making-it-inso.md)
+* [36807 - [SC-Critical] Attackers can create dynamic LOC with any credited amount with very small collateral amount](./36807-sc-critical-attackers-can-create-dynamic-loc-with-any-credited-amount-with-very-small-co....md)
 
 </details>
 
@@ -16,21 +17,22 @@
 
 <summary>Insight</summary>
 
-* \#36970 \[SC-Insight] Missing \`\_disableInitializer()\` implementation
-* \#36999 \[SC-Insight] Incomplete Adjustment of \`globalAmountInDynamicUse\` During LOC Liquidation Causes Accumulated Dust and DoS Risk
+* [36970 - [SC-Insight] Missing \`\_disableInitializer()\` implementation](./36970-sc-insight-missing-_disableinitializer-implementation.md)
+* [36999 - [SC-Insight] Incomplete Adjustment of \`globalAmountInDynamicUse\` During LOC Liquidation Causes Accumulated Dust and DoS Risk](./36999-sc-insight-incomplete-adjustment-of-globalamountindynamicuse-during-loc-liquidation-causes-acc.md)
 
 </details>
 
 ## Reports by Type
 
+[Smart Contract](<README.md#smart-contract>)
 <details>
 
 <summary>Smart Contract</summary>
 
-* \#36931 \[SC-Critical] Creators can modifyLOCCollateral of dynamic LOC to release almost all the collateral of LOC
-* \#36910 \[SC-Critical] LoC: The creator can withdraw the entire collateral of a Dynamic LoC making it insolvent
-* \#36970 \[SC-Insight] Missing \`\_disableInitializer()\` implementation
-* \#36999 \[SC-Insight] Incomplete Adjustment of \`globalAmountInDynamicUse\` During LOC Liquidation Causes Accumulated Dust and DoS Risk
-* \#36807 \[SC-Critical] Attackers can create dynamic LOC with any credited amount with very small collateral amount
+* [36931 - [SC-Critical] Creators can modifyLOCCollateral of dynamic LOC to release almost all the collateral of LOC](./36931-sc-critical-critical-creators-can-modifyloccollateral-of-dynamic-loc-to-release-.....md)
+* [36910 - [SC-Critical] LoC: The creator can withdraw the entire collateral of a Dynamic LoC making it insolvent](./36910-sc-critical-loc-the-creator-can-withdraw-the-entire-collateral-of-a-dynamic-loc-making-it-inso.md)
+* [36970 - [SC-Insight] Missing \`\_disableInitializer()\` implementation](./36970-sc-insight-missing-_disableinitializer-implementation.md)
+* [36999 - [SC-Insight] Incomplete Adjustment of \`globalAmountInDynamicUse\` During LOC Liquidation Causes Accumulated Dust and DoS Risk](./36999-sc-insight-incomplete-adjustment-of-globalamountindynamicuse-during-loc-liquidation-causes-acc.md)
+* [36807 - [SC-Critical] Attackers can create dynamic LOC with any credited amount with very small collateral amount](./36807-sc-critical-attackers-can-create-dynamic-loc-with-any-credited-amount-with-very-small-co....md)
 
 </details>

--- a/anvil/README.md
+++ b/anvil/README.md
@@ -2,11 +2,12 @@
 
 ## Reports by Severity
 
+[Critical](<README.md#critical>) | [Medium](<README.md#medium>) | [Low](<README.md#low>) | [Insight](<README.md#insight>)
 <details>
 
 <summary>Critical</summary>
 
-* \#36554 \[SC-Critical] Time Based Collateral Pool Users can release more than their due share of the pool, drawing from the due share of other users
+* [36554 - [SC - Critical] Time Based Collateral Pool Users can release more than their due share of the pool, drawing from the due share of other users](./36554-sc-critical-time-based-collateral-pool-users-can-release-more-than-their-due-share-of-the-pool.md)
 
 </details>
 
@@ -14,13 +15,13 @@
 
 <summary>Medium</summary>
 
-* \#36475 \[SC-Medium] Token allowance signature can be front-run
-* \#36532 \[SC-Medium] Frontrun to invalidate collateralizable approval signature
-* \#36552 \[SC-Medium] DoS for the user's calling \`stake\` and \`stakeReleasableTokensFrom\` function
-* \#36567 \[SC-Medium] Anyone can cancel anyone's LOC
-* \#36268 \[SC-Medium] stake with signature can be front-run lead to user's stake failed
-* \#36303 \[SC-Medium] Attackers can cause griefing attack to cause stake transactions of TimeBasedCollateralPool of users to always revert by front-running the user transaction to make the provided si...
-* \#36501 \[SC-Medium] Signature Front-Running Vulnerability in CollateralVault
+* [36475 - [SC - Medium] Token allowance signature can be front-run](./36475-sc-medium-token-allowance-signature-can-be-front-run.md)
+* [36532 - [SC - Medium] Frontrun to invalidate collateralizable approval signature](./36532-sc-medium-frontrun-to-invalidate-collateralizable-approval-signature.md)
+* [36552 - [SC - Medium] DoS for the user's calling \`stake\` and \`stakeReleasableTokensFrom\` function](./36552-sc-medium-dos-for-the-users-calling-stake-and-stakereleasabletokensfrom-function.md)
+* [36567 - [SC - Medium] Anyone can cancel anyone's LOC](./36567-sc-insight-anyone-can-cancel-anyones-loc.md)
+* [36268 - [SC - Medium] stake with signature can be front-run lead to user's stake failed](./36268-sc-medium-stake-with-signature-can-be-front-run-lead-to-users-stake-failed.md)
+* [36303 - [SC - Medium] Attackers can cause griefing attack to cause stake transactions of TimeBasedCollateralPool of users to always revert by front-running the user transaction to make the provided si...](./36303-sc-medium-attackers-can-cause-griefing-attack-to-cause-stake-transactions-of-timebasedcolla.md)
+* [36501 - [SC - Medium] Signature Front-Running Vulnerability in CollateralVault](./36501-sc-medium-signature-front-running-vulnerability-in-collateralvault.md)
 
 </details>
 
@@ -28,8 +29,8 @@
 
 <summary>Low</summary>
 
-* \#36309 \[SC-Low] TimeBasedCollateralPool: After \_resetPool gets called (internally) a depositor can break most functionalities of the smart contract
-* \#36450 \[SC-Low] Contract TimeBasedCollateralPool will be unable to process new user transactions and user funds are temporary frozen if a user unstake transaction of TimeBasedCollateralPool execute...
+* [36309 - [SC - Low] TimeBasedCollateralPool: After \_resetPool gets called (internally) a depositor can break most functionalities of the smart contract](./36309-sc-low-timebasedcollateralpool-after-_resetpool-gets-called-internally-a-depositor-can-break-m.md)
+* [36450 - [SC - Low] Contract TimeBasedCollateralPool will be unable to process new user transactions and user funds are temporary frozen if a user unstake transaction of TimeBasedCollateralPool execute...](./36450-sc-low-contract-timebasedcollateralpool-will-be-unable-to-process-new-user-transactions.md)
 
 </details>
 
@@ -37,38 +38,39 @@
 
 <summary>Insight</summary>
 
-* \#36340 \[SC-Insight] TimeBasedCollateralPool::\_resetAccountTokenStateIfApplicable does not adjust tokenEpochExitBalances after redeeming the account's unstake Units
-* \#36346 \[SC-Insight] Typehash Discrepancy in CollateralizableTokenAllowanceAdjustment
-* \#36306 \[SC-Insight] Incorrect nonce value emitted in \`TimeBasedCollateralPool::\_resetPool\` event
-* \#36540 \[SC-Insight] Users Can Withdraw Funds at Incorrect Fee Rate
-* \#36092 \[SC-Insight] Collateralizable Contracts May Retain Status Unconditionally
-* \#36136 \[SC-Insight] Fee calculation error in withdraw function of collateralVault contract
-* \#36267 \[SC-Insight] Tokens can be stuck forever in UniswapLiquidator because function retrieveTokens always reverts for USDT and all tokens that have transfer function that do not return boolean
+* [36340 - [SC - Insight] TimeBasedCollateralPool::\_resetAccountTokenStateIfApplicable does not adjust tokenEpochExitBalances after redeeming the account's unstake Units](./36340-sc-insight-timebasedcollateralpool-_resetaccounttokenstateifapplicable-does-not-adjust-tokenep.md)
+* [36346 - [SC - Insight] Typehash Discrepancy in CollateralizableTokenAllowanceAdjustment](./36346-sc-insight-typehash-discrepancy-in-collateralizabletokenallowanceadjustment.md)
+* [36306 - [SC - Insight] Incorrect nonce value emitted in \`TimeBasedCollateralPool::\_resetPool\` event](./36306-sc-insight-incorrect-nonce-value-emitted-in-timebasedcollateralpool-_resetpool-event.md)
+* [36540 - [SC - Insight] Users Can Withdraw Funds at Incorrect Fee Rate](./36540-sc-insight-users-can-withdraw-funds-at-incorrect-fee-rate.md)
+* [36092 - [SC - Insight] Collateralizable Contracts May Retain Status Unconditionally](./36092-sc-insight-collateralizable-contracts-may-retain-status-unconditionally.md)
+* [36136 - [SC - Insight] Fee calculation error in withdraw function of collateralVault contract](./36136-sc-insight-fee-calculation-error-in-withdraw-function-of-collateralvault-contract.md)
+* [36267 - [SC - Insight] Tokens can be stuck forever in UniswapLiquidator because function retrieveTokens always reverts for USDT and all tokens that have transfer function that do not return boolean](./36267-sc-insight-tokens-can-be-stuck-forever-in-uniswapliquidator-because-function-retrievetokens.md)
 
 </details>
 
 ## Reports by Type
 
+[Smart Contract](<README.md#smart-contract>)
 <details>
 
 <summary>Smart Contract</summary>
 
-* \#36309 \[SC-Low] TimeBasedCollateralPool: After \_resetPool gets called (internally) a depositor can break most functionalities of the smart contract
-* \#36340 \[SC-Insight] TimeBasedCollateralPool::\_resetAccountTokenStateIfApplicable does not adjust tokenEpochExitBalances after redeeming the account's unstake Units
-* \#36346 \[SC-Insight] Typehash Discrepancy in CollateralizableTokenAllowanceAdjustment
-* \#36450 \[SC-Low] Contract TimeBasedCollateralPool will be unable to process new user transactions and user funds are temporary frozen if a user unstake transaction of TimeBasedCollateralPool execute...
-* \#36475 \[SC-Medium] Token allowance signature can be front-run
-* \#36306 \[SC-Insight] Incorrect nonce value emitted in \`TimeBasedCollateralPool::\_resetPool\` event
-* \#36532 \[SC-Medium] Frontrun to invalidate collateralizable approval signature
-* \#36552 \[SC-Medium] DoS for the user's calling \`stake\` and \`stakeReleasableTokensFrom\` function
-* \#36554 \[SC-Critical] Time Based Collateral Pool Users can release more than their due share of the pool, drawing from the due share of other users
-* \#36567 \[SC-Medium] Anyone can cancel anyone's LOC
-* \#36540 \[SC-Insight] Users Can Withdraw Funds at Incorrect Fee Rate
-* \#36092 \[SC-Insight] Collateralizable Contracts May Retain Status Unconditionally
-* \#36136 \[SC-Insight] Fee calculation error in withdraw function of collateralVault contract
-* \#36267 \[SC-Insight] Tokens can be stuck forever in UniswapLiquidator because function retrieveTokens always reverts for USDT and all tokens that have transfer function that do not return boolean
-* \#36268 \[SC-Medium] stake with signature can be front-run lead to user's stake failed
-* \#36303 \[SC-Medium] Attackers can cause griefing attack to cause stake transactions of TimeBasedCollateralPool of users to always revert by front-running the user transaction to make the provided si...
-* \#36501 \[SC-Medium] Signature Front-Running Vulnerability in CollateralVault
+* [36309 - [SC - Low] TimeBasedCollateralPool: After \_resetPool gets called (internally) a depositor can break most functionalities of the smart contract](./36309-sc-low-timebasedcollateralpool-after-_resetpool-gets-called-internally-a-depositor-can-break-m.md)
+* [36340 - [SC - Insight] TimeBasedCollateralPool::\_resetAccountTokenStateIfApplicable does not adjust tokenEpochExitBalances after redeeming the account's unstake Units](./36340-sc-insight-timebasedcollateralpool-_resetaccounttokenstateifapplicable-does-not-adjust-tokenep.md)
+* [36346 - [SC - Insight] Typehash Discrepancy in CollateralizableTokenAllowanceAdjustment](./36346-sc-insight-typehash-discrepancy-in-collateralizabletokenallowanceadjustment.md)
+* [36450 - [SC - Low] Contract TimeBasedCollateralPool will be unable to process new user transactions and user funds are temporary frozen if a user unstake transaction of TimeBasedCollateralPool execute...](./36450-sc-low-contract-timebasedcollateralpool-will-be-unable-to-process-new-user-transactions.md)
+* [36475 - [SC - Medium] Token allowance signature can be front-run](./36475-sc-medium-token-allowance-signature-can-be-front-run.md)
+* [36306 - [SC - Insight] Incorrect nonce value emitted in \`TimeBasedCollateralPool::\_resetPool\` event](./36306-sc-insight-incorrect-nonce-value-emitted-in-timebasedcollateralpool-_resetpool-event.md)
+* [36532 - [SC - Medium] Frontrun to invalidate collateralizable approval signature](./36532-sc-medium-frontrun-to-invalidate-collateralizable-approval-signature.md)
+* [36552 - [SC - Medium] DoS for the user's calling \`stake\` and \`stakeReleasableTokensFrom\` function](./36552-sc-medium-dos-for-the-users-calling-stake-and-stakereleasabletokensfrom-function.md)
+* [36554 - [SC - Critical] Time Based Collateral Pool Users can release more than their due share of the pool, drawing from the due share of other users](./36554-sc-critical-time-based-collateral-pool-users-can-release-more-than-their-due-share-of-the-pool.md)
+* [36567 - [SC - Medium] Anyone can cancel anyone's LOC](./36567-sc-insight-anyone-can-cancel-anyones-loc.md)
+* [36540 - [SC - Insight] Users Can Withdraw Funds at Incorrect Fee Rate](./36540-sc-insight-users-can-withdraw-funds-at-incorrect-fee-rate.md)
+* [36092 - [SC - Insight] Collateralizable Contracts May Retain Status Unconditionally](./36092-sc-insight-collateralizable-contracts-may-retain-status-unconditionally.md)
+* [36136 - [SC - Insight] Fee calculation error in withdraw function of collateralVault contract](./36136-sc-insight-fee-calculation-error-in-withdraw-function-of-collateralvault-contract.md)
+* [36267 - [SC - Insight] Tokens can be stuck forever in UniswapLiquidator because function retrieveTokens always reverts for USDT and all tokens that have transfer function that do not return boolean](./36267-sc-insight-tokens-can-be-stuck-forever-in-uniswapliquidator-because-function-retrievetokens.md)
+* [36268 - [SC - Medium] stake with signature can be front-run lead to user's stake failed](./36268-sc-medium-stake-with-signature-can-be-front-run-lead-to-users-stake-failed.md)
+* [36303 - [SC - Medium] Attackers can cause griefing attack to cause stake transactions of TimeBasedCollateralPool of users to always revert by front-running the user transaction to make the provided si...](./36303-sc-medium-attackers-can-cause-griefing-attack-to-cause-stake-transactions-of-timebasedcolla.md)
+* [36501 - [SC - Medium] Signature Front-Running Vulnerability in CollateralVault](./36501-sc-medium-signature-front-running-vulnerability-in-collateralvault.md)
 
 </details>

--- a/butter/README.md
+++ b/butter/README.md
@@ -2,11 +2,12 @@
 
 ## Reports by Severity
 
+[Low](<README.md#low>) | [Insight](<README.md#insight>)
 <details>
 
 <summary>Low</summary>
 
-* \#39495 \[SC-Low] FlatCFM cannot be resolved in case answer of questionId are in greater or equal to 2^OUTCOME\_COUNT and answer % 2^OUTCOME\_COUNT is 0
+* [39495 - [SC - Low] FlatCFM cannot be resolved in case answer of questionId are in greater or equal to 2^OUTCOME\_COUNT and answer % 2^OUTCOME\_COUNT is 0](./39495-sc-low-flatcfm-cannot-be-resolved-in-case-answer-of-questionid-are-in-greater-or-equal-to-2-ou.md)
 
 </details>
 
@@ -14,31 +15,32 @@
 
 <summary>Insight</summary>
 
-* \#39153 \[SC-Insight] Unauthorized Token Creation and Minting Vulnerability
-* \#39271 \[SC-Insight] Check \`numericAnswer\` before external call to check answer is valid or not
-* \#39528 \[SC-Insight] Lack of Validation for Min and Max Values in FlatCFMFactory leads to wrong payouts
-* \#39539 \[SC-Insight] Insufficient validation of tokens when created in \`PlayCollateralTokenFactory::createCollateralToken\`
-* \#39181 \[SC-Insight] Bond Fund will be Lost When Question is Asked Again
-* \#39243 \[SC-Insight] Misleading Comment in merge Function Regarding Token Transfers to wrapped1155Factory
-* \#39524 \[SC-Insight] Incorrect Outcome Formatting in Reality Adapter Leads to Wrong Number of Outcomes
-* \#39487 \[SC-Insight] flatCfmImplementation and conditionalScalarMarketImplementation contracts can be initialized by anyone
+* [39153 - [SC - Insight] Unauthorized Token Creation and Minting Vulnerability](./39153-sc-insight-unauthorized-token-creation-and-minting-vulnerability.md)
+* [39271 - [SC - Insight] Check \`numericAnswer\` before external call to check answer is valid or not](./39271-sc-insight-check-numericanswer-before-external-call-to-check-answer-is-valid-or-not.md)
+* [39528 - [SC - Insight] Lack of Validation for Min and Max Values in FlatCFMFactory leads to wrong payouts](./39528-sc-insight-lack-of-validation-for-min-and-max-values-in-flatcfmfactory-leads-to-wrong-payouts.md)
+* [39539 - [SC - Insight] Insufficient validation of tokens when created in \`PlayCollateralTokenFactory::createCollateralToken\`](./39539-sc-insight-insufficient-validation-of-tokens-when-created-in-playcollateraltokenfactory-create.md)
+* [39181 - [SC - Insight] Bond Fund will be Lost When Question is Asked Again](./39181-sc-insight-bond-fund-will-be-lost-when-question-is-asked-again.md)
+* [39243 - [SC - Insight] Misleading Comment in merge Function Regarding Token Transfers to wrapped1155Factory](./39243-sc-insight-misleading-comment-in-merge-function-regarding-token-transfers-to-wrapped1155factor.md)
+* [39524 - [SC - Insight] Incorrect Outcome Formatting in Reality Adapter Leads to Wrong Number of Outcomes](./39524-sc-insight-incorrect-outcome-formatting-in-reality-adapter-leads-to-wrong-number-of-outcomes.md)
+* [39487 - [SC - Insight] flatCfmImplementation and conditionalScalarMarketImplementation contracts can be initialized by anyone](./39487-sc-insight-flatcfmimplementation-and-conditionalscalarmarketimplementation-contracts-can-be-in.md)
 
 </details>
 
 ## Reports by Type
 
+[Smart Contract](<README.md#smart-contract>)
 <details>
 
 <summary>Smart Contract</summary>
 
-* \#39153 \[SC-Insight] Unauthorized Token Creation and Minting Vulnerability
-* \#39271 \[SC-Insight] Check \`numericAnswer\` before external call to check answer is valid or not
-* \#39495 \[SC-Low] FlatCFM cannot be resolved in case answer of questionId are in greater or equal to 2^OUTCOME\_COUNT and answer % 2^OUTCOME\_COUNT is 0
-* \#39528 \[SC-Insight] Lack of Validation for Min and Max Values in FlatCFMFactory leads to wrong payouts
-* \#39539 \[SC-Insight] Insufficient validation of tokens when created in \`PlayCollateralTokenFactory::createCollateralToken\`
-* \#39181 \[SC-Insight] Bond Fund will be Lost When Question is Asked Again
-* \#39243 \[SC-Insight] Misleading Comment in merge Function Regarding Token Transfers to wrapped1155Factory
-* \#39524 \[SC-Insight] Incorrect Outcome Formatting in Reality Adapter Leads to Wrong Number of Outcomes
-* \#39487 \[SC-Insight] flatCfmImplementation and conditionalScalarMarketImplementation contracts can be initialized by anyone
+* [39153 - [SC - Insight] Unauthorized Token Creation and Minting Vulnerability](./39153-sc-insight-unauthorized-token-creation-and-minting-vulnerability.md)
+* [39271 - [SC - Insight] Check \`numericAnswer\` before external call to check answer is valid or not](./39271-sc-insight-check-numericanswer-before-external-call-to-check-answer-is-valid-or-not.md)
+* [39495 - [SC - Low] FlatCFM cannot be resolved in case answer of questionId are in greater or equal to 2^OUTCOME\_COUNT and answer % 2^OUTCOME\_COUNT is 0](./39495-sc-low-flatcfm-cannot-be-resolved-in-case-answer-of-questionid-are-in-greater-or-equal-to-2-ou.md)
+* [39528 - [SC - Insight] Lack of Validation for Min and Max Values in FlatCFMFactory leads to wrong payouts](./39528-sc-insight-lack-of-validation-for-min-and-max-values-in-flatcfmfactory-leads-to-wrong-payouts.md)
+* [39539 - [SC - Insight] Insufficient validation of tokens when created in \`PlayCollateralTokenFactory::createCollateralToken\`](./39539-sc-insight-insufficient-validation-of-tokens-when-created-in-playcollateraltokenfactory-create.md)
+* [39181 - [SC - Insight] Bond Fund will be Lost When Question is Asked Again](./39181-sc-insight-bond-fund-will-be-lost-when-question-is-asked-again.md)
+* [39243 - [SC - Insight] Misleading Comment in merge Function Regarding Token Transfers to wrapped1155Factory](./39243-sc-insight-misleading-comment-in-merge-function-regarding-token-transfers-to-wrapped1155factor.md)
+* [39524 - [SC - Insight] Incorrect Outcome Formatting in Reality Adapter Leads to Wrong Number of Outcomes](./39524-sc-insight-incorrect-outcome-formatting-in-reality-adapter-leads-to-wrong-number-of-outcomes.md)
+* [39487 - [SC - Insight] flatCfmImplementation and conditionalScalarMarketImplementation contracts can be initialized by anyone](./39487-sc-insight-flatcfmimplementation-and-conditionalscalarmarketimplementation-contracts-can-be-in.md)
 
 </details>

--- a/celo/README.md
+++ b/celo/README.md
@@ -2,13 +2,14 @@
 
 ## Reports by Severity
 
+[Critical](<README.md#critical>) | [High](<README.md#high>) | [Medium](<README.md#medium>) | [Insight](<README.md#insight>)
 <details>
 
 <summary>Critical</summary>
 
-* \#37251 \[SC-Critical] Fraudulent padding of governance voting power
-* \#37285 \[SC-Critical] Incorrect Delegation State After Slashing in LockedGold Contract
-* \#37427 \[SC-Critical] Delegation is not updated on slash and unlock
+* [37251 - [SC - Critical] Fraudulent padding of governance voting power](./37251-sc-critical-fraudulent-padding-of-governance-voting-power.md)
+* [37285 - [SC - Critical] Incorrect Delegation State After Slashing in LockedGold Contract](./37285-sc-critical-incorrect-delegation-state-after-slashing-in-lockedgold-contract.md)
+* [37427 - [SC - Critical] Delegation is not updated on slash and unlock](./37427-sc-critical-delegation-is-not-updated-on-slash-and-unlock.md)
 
 </details>
 
@@ -16,9 +17,9 @@
 
 <summary>High</summary>
 
-* \#37391 \[SC-High] Early Reward Accrual Undermines Validator Group Performance Incentives
-* \#37010 \[SC-High] Rollback of the incorrect state interferes with the progress of the epoch process, prevents the user from receiving rewards, blocks the launch of the associated contract function, etc
-* \#37058 \[SC-High] Theft of remuneration through claims processing loops.
+* [37391 - [SC - High] Early Reward Accrual Undermines Validator Group Performance Incentives](./37391-sc-high-early-reward-accrual-undermines-validator-group-performance-incentives.md)
+* [37010 - [SC - High] Rollback of the incorrect state interferes with the progress of the epoch process, prevents the user from receiving rewards, blocks the launch of the associated contract function, etc](./37010-sc-high-rollback-of-the-incorrect-state-interferes-with-the-progress-of-the-epoch-process-prev.md)
+* [37058 - [SC - High] Theft of remuneration through claims processing loops.](./37058-sc-high-theft-of-remuneration-through-claims-processing-loops..md)
 
 </details>
 
@@ -26,7 +27,7 @@
 
 <summary>Medium</summary>
 
-* \#37206 \[SC-Medium] Overflow due to lack of checks leading to incorrect price calculation
+* [37206 - [SC - Medium] Overflow due to lack of checks leading to incorrect price calculation](./37206-sc-medium-overflow-due-to-lack-of-checks-leading-to-incorrect-price-calculation.md)
 
 </details>
 
@@ -34,23 +35,24 @@
 
 <summary>Insight</summary>
 
-* \#37443 \[SC-Insight] Race Condition in KeyedBroadcaster Implementation
+* [37443 - [SC - Insight] Race Condition in KeyedBroadcaster Implementation](./37443-sc-insight-race-condition-in-keyedbroadcaster-implementation.md)
 
 </details>
 
 ## Reports by Type
 
+[Smart Contract](<README.md#smart-contract>)
 <details>
 
 <summary>Smart Contract</summary>
 
-* \#37251 \[SC-Critical] Fraudulent padding of governance voting power
-* \#37391 \[SC-High] Early Reward Accrual Undermines Validator Group Performance Incentives
-* \#37010 \[SC-High] Rollback of the incorrect state interferes with the progress of the epoch process, prevents the user from receiving rewards, blocks the launch of the associated contract function, etc
-* \#37285 \[SC-Critical] Incorrect Delegation State After Slashing in LockedGold Contract
-* \#37058 \[SC-High] Theft of remuneration through claims processing loops.
-* \#37443 \[SC-Insight] Race Condition in KeyedBroadcaster Implementation
-* \#37206 \[SC-Medium] Overflow due to lack of checks leading to incorrect price calculation
-* \#37427 \[SC-Critical] Delegation is not updated on slash and unlock
+* [37251 - [SC - Critical] Fraudulent padding of governance voting power](./37251-sc-critical-fraudulent-padding-of-governance-voting-power.md)
+* [37391 - [SC - High] Early Reward Accrual Undermines Validator Group Performance Incentives](./37391-sc-high-early-reward-accrual-undermines-validator-group-performance-incentives.md)
+* [37010 - [SC - High] Rollback of the incorrect state interferes with the progress of the epoch process, prevents the user from receiving rewards, blocks the launch of the associated contract function, etc](./37010-sc-high-rollback-of-the-incorrect-state-interferes-with-the-progress-of-the-epoch-process-prev.md)
+* [37285 - [SC - Critical] Incorrect Delegation State After Slashing in LockedGold Contract](./37285-sc-critical-incorrect-delegation-state-after-slashing-in-lockedgold-contract.md)
+* [37058 - [SC - High] Theft of remuneration through claims processing loops.](./37058-sc-high-theft-of-remuneration-through-claims-processing-loops..md)
+* [37443 - [SC - Insight] Race Condition in KeyedBroadcaster Implementation](./37443-sc-insight-race-condition-in-keyedbroadcaster-implementation.md)
+* [37206 - [SC - Medium] Overflow due to lack of checks leading to incorrect price calculation](./37206-sc-medium-overflow-due-to-lack-of-checks-leading-to-incorrect-price-calculation.md)
+* [37427 - [SC - Critical] Delegation is not updated on slash and unlock](./37427-sc-critical-delegation-is-not-updated-on-slash-and-unlock.md)
 
 </details>

--- a/ethereum-protocol-attackathon/README.md
+++ b/ethereum-protocol-attackathon/README.md
@@ -6,16 +6,17 @@ hidden: true
 
 ## Reports by Severity
 
+[Medium](<README.md#medium>) | [Low](<README.md#low>) | [Insight](<README.md#insight>)
 <details>
 
 <summary>Medium</summary>
 
-* \#37466 \[BC-Medium] Evil-client OOM crash (fast P2P crash)
-* \#38292 \[SC-Medium] Incorrect Sqrt Calculation Result
-* \#38682 \[SC-Medium] AugAssign evaluation order causing OOB write within the object
-* \#38733 \[BC-Medium] nibmus-eth2 remote crash
-* \#38920 \[BC-Medium] teku remote DoS
-* \#38146 \[BC-Medium] nimbus-eth2 remote crash
+* [37466 - [BC - Medium] Evil-client OOM crash (fast P2P crash)](./37466-bc-medium-evil-client-oom-crash-fast-p2p-crash.md)
+* [38292 - [SC - Medium] Incorrect Sqrt Calculation Result](./38292-sc-medium-incorrect-sqrt-calculation-result.md)
+* [38682 - [SC - Medium] AugAssign evaluation order causing OOB write within the object](./38682-sc-medium-augassign-evaluation-order-causing-oob-write-within-the-object.md)
+* [38733 - [BC - Medium] nibmus-eth2 remote crash](./38733-bc-medium-nibmus-eth2-remote-crash.md)
+* [38920 - [BC - Medium] teku remote DoS](./38920-bc-medium-teku-remote-dos.md)
+* [38146 - [BC - Medium] nimbus-eth2 remote crash](./38146-bc-medium-nimbus-eth2-remote-crash.md)
 
 </details>
 
@@ -23,33 +24,33 @@ hidden: true
 
 <summary>Low</summary>
 
-* \#38502 \[BC-Low] Pending pool subtraction overflow causes node halt/shutdown
-* \#38505 \[SC-Low] IRNode Multi-Evaluation In For List Iter
-* \#38530 \[SC-Low] Incorrectly Eliminated Code With Side Effect In Concat Args
-* \#38554 \[BC-Low] Incorrect Transaction Fee Check in \`SendRawTransaction()\`
-* \#37199 \[BC-Low] Potential Chain Fork Due to Shallow Copy of Byte Slice
-* \#37245 \[BC-Low] lodestar snappy decompression issue
-* \#38686 \[BC-Low] Nodes with trusted peers vulnerable to pending peer flooding and DoS
-* \#37985 \[SC-Low] Incorrectly Eliminate Code With Side Effect In Slice Args
-* \#38807 \[BC-Low] DoS any reth node via ban logic exploit
-* \#37462 \[BC-Low] Invalid RLP decoding for single bytes
-* \#38850 \[BC-Low] Remote P2P OOM Crash (GetBlockHeaders) / Reth
-* \#38855 \[SC-Low] Evaluation order is not respected in \`log\` function
-* \#38894 \[BC-Low] Missing expiration check for Pong and Neighbors packets and not refreshing the endpoint proof
-* \#38275 \[BC-Low] Evil-client P2P headers-traversal leads to D/DoS and total peer removal
-* \#37582 \[SC-Low] Incorrect HexString Parsing Leads To Compilation Error Or Type Confusion
-* \#37583 \[SC-Low] Incorrect For Annotation Parsing
-* \#38958 \[BC-Low] EELS cant handle overflow gas calculation in modexp precompile
-* \#38828 \[BC-Low] Decode RLP of Legacy Transaction Allows Tailing Bytes
-* \#37113 \[BC-Low] A potential out-of-range panic has been discovered in the Ethereum client Erigon ( https://github.com/erigontech/erigon ), though it does not seem to be exploitable at this moment du...
-* \#38459 \[BC-Low] erigon remote DoS
-* \#37246 \[BC-Low] lodestar snappy checksum issue
-* \#37634 \[SC-Low] Incorrect Builtin ERC4626 Call Signature
-* \#38427 \[BC-Low] Discrepancy in Intrinsic Gas Calculation between Txpool and EVM Execution
-* \#38902 \[BC-Low] No check on the maximum size of the encoded ENR on ENR\_RESPONSE packet
-* \#38948 \[BC-Low] lighthouse remote DoS
-* \#38278 \[BC-Low] Potential DoS to Mempool Due to Missing Gas Limit Check
-* \#38318 \[BC-Low] nimbus-eth2: Gossipsub misconfiguration allows malicious peers gossip malformed data without penalization
+* [38502 - [BC - Low] Pending pool subtraction overflow causes node halt/shutdown](./38502-bc-low-pending-pool-subtraction-overflow-causes-node-halt-shutdown.md)
+* [38505 - [SC - Low] IRNode Multi-Evaluation In For List Iter](./38505-sc-low-irnode-multi-evaluation-in-for-list-iter.md)
+* [38530 - [SC - Low] Incorrectly Eliminated Code With Side Effect In Concat Args](./38530-sc-low-incorrectly-eliminated-code-with-side-effect-in-concat-args.md)
+* [38554 - [BC - Low] Incorrect Transaction Fee Check in \`SendRawTransaction()\`](./38554-bc-low-incorrect-transaction-fee-check-in-sendrawtransaction.md)
+* [37199 - [BC - Low] Potential Chain Fork Due to Shallow Copy of Byte Slice](./37199-bc-low-potential-chain-fork-due-to-shallow-copy-of-byte-slice.md)
+* [37245 - [BC - Low] lodestar snappy decompression issue](./37245-bc-low-lodestar-snappy-decompression-issue.md)
+* [38686 - [BC - Low] Nodes with trusted peers vulnerable to pending peer flooding and DoS](./38686-bc-low-nodes-with-trusted-peers-vulnerable-to-pending-peer-flooding-and-dos.md)
+* [37985 - [SC - Low] Incorrectly Eliminate Code With Side Effect In Slice Args](./37985-sc-low-incorrectly-eliminate-code-with-side-effect-in-slice-args.md)
+* [38807 - [BC - Low] DoS any reth node via ban logic exploit](./38807-bc-low-dos-any-reth-node-via-ban-logic-exploit.md)
+* [37462 - [BC - Low] Invalid RLP decoding for single bytes](./37462-bc-low-invalid-rlp-decoding-for-single-bytes.md)
+* [38850 - [BC - Low] Remote P2P OOM Crash (GetBlockHeaders) / Reth](./38850-bc-low-remote-p2p-oom-crash-getblockheaders-reth.md)
+* [38855 - [SC - Low] Evaluation order is not respected in \`log\` function](./38855-sc-low-evaluation-order-is-not-respected-in-log-function.md)
+* [38894 - [BC - Low] Missing expiration check for Pong and Neighbors packets and not refreshing the endpoint proof](./38894-bc-low-missing-expiration-check-for-pong-and-neighbors-packets-and-not-refreshing-the-endpoint.md)
+* [38275 - [BC - Low] Evil-client P2P headers-traversal leads to D/DoS and total peer removal](./38275-bc-low-evil-client-p2p-headers-traversal-leads-to-d-dos-and-total-peer-removal.md)
+* [37582 - [SC - Low] Incorrect HexString Parsing Leads To Compilation Error Or Type Confusion](./37582-sc-low-incorrect-hexstring-parsing-leads-to-compilation-error-or-type-confusion.md)
+* [37583 - [SC - Low] Incorrect For Annotation Parsing](./37583-sc-low-incorrect-for-annotation-parsing.md)
+* [38958 - [BC - Low] EELS cant handle overflow gas calculation in modexp precompile](./38958-bc-low-eels-cant-handle-overflow-gas-calculation-in-modexp-precompile.md)
+* [38828 - [BC - Low] Decode RLP of Legacy Transaction Allows Tailing Bytes](./38828-bc-low-decode-rlp-of-legacy-transaction-allows-tailing-bytes.md)
+<!-- * [37113 - [BC - Low] A potential out-of-range panic has been discovered in the Ethereum client Erigon ( https://github.com/erigontech/erigon ), though it does not seem to be exploitable at this moment du...]() -->
+<!-- * [38459 - [BC - Low] erigon remote DoS]() -->
+* [37246 - [BC - Low] lodestar snappy checksum issue](./37246-bc-low-lodestar-snappy-checksum-issue.md)
+* [37634 - [SC - Low] Incorrect Builtin ERC4626 Call Signature](./37634-sc-low-incorrect-builtin-erc4626-call-signature.md)
+* [38427 - [BC - Low] Discrepancy in Intrinsic Gas Calculation between Txpool and EVM Execution](./38427-bc-low-discrepancy-in-intrinsic-gas-calculation-between-txpool-and-evm-execution.md)
+* [38902 - [BC - Low] No check on the maximum size of the encoded ENR on ENR\_RESPONSE packet](./38902-bc-low-no-check-on-the-maximum-size-of-the-encoded-enr-on-enr_response-packet.md)
+* [38948 - [BC - Low] lighthouse remote DoS](./38948-bc-low-lighthouse-remote-dos.md)
+* [38278 - [BC - Low] Potential DoS to Mempool Due to Missing Gas Limit Check](./38278-bc-low-potential-dos-to-mempool-due-to-missing-gas-limit-check.md)
+* [38318 - [BC - Low] nimbus-eth2: Gossipsub misconfiguration allows malicious peers gossip malformed data without penalization](./38318-bc-low-nimbus-eth2-gossipsub-misconfiguration-allows-malicious-peers-gossip-malformed-data-wit.md)
 
 </details>
 
@@ -57,124 +58,126 @@ hidden: true
 
 <summary>Insight</summary>
 
-* \#37646 \[BC-Insight] No implementation of BLOB\_SIDECAR\_SUBNET\_COUNT with no issue and no PR in the GitHub
-* \#37134 \[BC-Insight] Improper secp256k sanitization
-* \#37695 \[BC-Insight] Executing transaction that has a wrong nonce might triggered a chain split due to mismatch stateroot
-* \#37120 \[BC-Insight] Remote handshake-based TCP/30303 flooding leads to an out-of-memory crash
-* \#37191 \[BC-Insight] Unvalidated Field Names in Tuple ABI Parsing Causes Runtime Panic via reflect.StructOf
-* \#37593 \[BC-Insight] Inconsistent Address Collision Check Against Precompile Contracts During Contract Deployment
-* \#38598 \[BC-Insight] GetReceiptsMsg abuse leads to the DoS and/or crash of every EL client in the Ethereum network
-* \#37352 \[BC-Insight] Missing Liveness Check in \`collectTableNodes()\`
-* \#37359 \[BC-Insight] Failure to Generate ABI Binding in Golang
-* \#37351 \[BC-Insight] Resubscribe Deadlocks When Unsubscribing Within An Unblock Channel
-* \#38766 \[BC-Insight] Nil Pointer Dereference Panics in encodePayload() of Blob Tx’s Encoding
-* \#37442 \[BC-Insight] Potential Address Collision with Precompile Contract During Contract Deployment
-* \#38169 \[SC-Insight] Deferred Evaluation Of \`Default\_Return\_Value\` May Skip Side Effect Execution
-* \#37483 \[BC-Insight] There is a trace discrepancy for Nethermind when handling EOF from PUSH opcode
-* \#37505 \[BC-Insight] Remotely spamming 1 byte leads to full peer removal and desync in both execution and consensus clients
-* \#37568 \[BC-Insight] Missing Specification Logic
-* \#37300 \[BC-Insight] Incorrect Encoding of Negative \*big.Int Values in MakeTopics
-* \#38277 \[BC-Insight] Potential Out-of-Range Panic in \`UnmarshalJSON()\` of \`HexOrDecimal256\`
-* \#38908 \[BC-Insight] Missing Failed Subcalls in Erigon Tracers When Encountering \`ErrInsufficientBalance\` Error
-* \#39018 \[BC-Insight] Rate Limiting Under-Specification and Consequences
-* \#37286 \[SC-Insight] Elimination of Security Checks in ForkCreator Class
-* \#37148 \[BC-Insight] \`wantedPeerDials()\` branch will never be executed
-* \#38557 \[BC-Insight] Function \`IsPush()\` Misses Opcode PUSH0
-* \#37584 \[SC-Insight] Nonpayable Not Respected For Internal Function
-* \#38581 \[SC-Insight] Incorrect unwrap on Bytes and String
-* \#37210 \[BC-Insight] Missing Check of HTTP Batch Response Length
-* \#37350 \[BC-Insight] \`null\` Is Not Unmarshalled Correctly Into json.RawMessage
-* \#37104 \[BC-Insight] Reth RPC is vulnerable to DNS rebinding attacks
-* \#38015 \[BC-Insight] Violation of EIP-2681 in Create Transaction
-* \#37186 \[BC-Insight] Missing Validation for Fixed-Size bytes Types in ABI Parsing
-* \#38319 \[BC-Insight] Edge case difference for GETH and NETHERMIND when calculating memory expansion gas
-* \#37594 \[SC-Insight] Nimbus incorrectly rejects non-minimally encoded snappy data length's due to spec. ambiguity
-* \#37153 \[BC-Insight] Malicious validator can bring down honest nodes
-* \#37577 \[BC-Insight] \`tx.origin\` Usage in Group Management Contract Allows Phishing Attack for Unauthorized Actions
-* \#38693 \[SC-Insight] BytesM to Bytes conversion does not match the reference implementation
+* [37646 - [BC - Insight] No implementation of BLOB\_SIDECAR\_SUBNET\_COUNT with no issue and no PR in the GitHub](./37646-bc-insight-no-implementation-of-blob_sidecar_subnet_count-with-no-issue-and-no-pr-in-the-githu.md)
+* [37134 - [BC - Insight] Improper secp256k sanitization](./37134-bc-insight-improper-secp256k-sanitization.md)
+* [37695 - [BC - Insight] Executing transaction that has a wrong nonce might triggered a chain split due to mismatch stateroot](./37695-bc-insight-executing-transaction-that-has-a-wrong-nonce-might-triggered-a-chain-split-due-to-m.md)
+* [37120 - [BC - Insight] Remote handshake-based TCP/30303 flooding leads to an out-of-memory crash](./37120-bc-insight-remote-handshake-based-tcp-30303-flooding-leads-to-an-out-of-memory-crash.md)
+* [37191 - [BC - Insight] Unvalidated Field Names in Tuple ABI Parsing Causes Runtime Panic via reflect.StructOf](./37191-bc-insight-unvalidated-field-names-in-tuple-abi-parsing-causes-runtime-panic-via-reflect.struc.md)
+* [37593 - [BC - Insight] Inconsistent Address Collision Check Against Precompile Contracts During Contract Deployment](./37593-bc-insight-inconsistent-address-collision-check-against-precompile-contracts-during-contract-d.md)
+* [38598 - [BC - Insight] GetReceiptsMsg abuse leads to the DoS and/or crash of every EL client in the Ethereum network](./38598-bc-insight-getreceiptsmsg-abuse-leads-to-the-dos-and-or-crash-of-every-el-client-in-the-ethere.md)
+* [37352 - [BC - Insight] Missing Liveness Check in \`collectTableNodes()\`](./37352-bc-insight-missing-liveness-check-in-collecttablenodes.md)
+* [37359 - [BC - Insight] Failure to Generate ABI Binding in Golang](./37359-bc-insight-failure-to-generate-abi-binding-in-golang.md)
+* [37351 - [BC - Insight] Resubscribe Deadlocks When Unsubscribing Within An Unblock Channel](./37351-bc-insight-resubscribe-deadlocks-when-unsubscribing-within-an-unblock-channel.md)
+* [38766 - [BC - Insight] Nil Pointer Dereference Panics in encodePayload() of Blob Tx’s Encoding](./38766-bc-insight-nil-pointer-dereference-panics-in-encodepayload-of-blob-txs-encoding.md)
+* [37442 - [BC - Insight] Potential Address Collision with Precompile Contract During Contract Deployment](./37442-bc-insight-potential-address-collision-with-precompile-contract-during-contract-deployment.md)
+* [38169 - [SC - Insight] Deferred Evaluation Of \`Default\_Return\_Value\` May Skip Side Effect Execution](./38169-sc-insight-deferred-evaluation-of-default_return_value-may-skip-side-effect-execution.md)
+* [37483 - [BC - Insight] There is a trace discrepancy for Nethermind when handling EOF from PUSH opcode](./37483-bc-insight-there-is-a-trace-discrepancy-for-nethermind-when-handling-eof-from-push-opcode.md)
+* [37505 - [BC - Insight] Remotely spamming 1 byte leads to full peer removal and desync in both execution and consensus clients](./37505-bc-insight-remotely-spamming-1-byte-leads-to-full-peer-removal-and-desync-in-both-execution-an.md)
+* [37568 - [BC - Insight] Missing Specification Logic](./37568-bc-insight-missing-specification-logic.md)
+* [37300 - [BC - Insight] Incorrect Encoding of Negative \*big.Int Values in MakeTopics](./37300-bc-insight-incorrect-encoding-of-negative-big.int-values-in-maketopics.md)
+* [38277 - [BC - Insight] Potential Out-of-Range Panic in \`UnmarshalJSON()\` of \`HexOrDecimal256\`](./38277-bc-insight-potential-out-of-range-panic-in-unmarshaljson-of-hexordecimal256.md)
+* [38908 - [BC - Insight] Missing Failed Subcalls in Erigon Tracers When Encountering \`ErrInsufficientBalance\` Error](./38908-bc-insight-missing-failed-subcalls-in-erigon-tracers-when-encountering-errinsufficientbalance.md)
+* [39018 - [BC - Insight] Rate Limiting Under-Specification and Consequences](./39018-bc-insight-rate-limiting-under-specification-and-consequences.md)
+* [37286 - [SC - Insight] Elimination of Security Checks in ForkCreator Class](./37286-sc-insight-elimination-of-security-checks-in-forkcreator-class.md)
+* [37148 - [BC - Insight] \`wantedPeerDials()\` branch will never be executed](./37148-bc-insight-wantedpeerdials-branch-will-never-be-executed.md)
+* [38557 - [BC - Insight] Function \`IsPush()\` Misses Opcode PUSH0](./38557-bc-insight-function-ispush-misses-opcode-push0.md)
+* [37584 - [SC - Insight] Nonpayable Not Respected For Internal Function](./37584-sc-insight-nonpayable-not-respected-for-internal-function.md)
+* [38581 - [SC - Insight] Incorrect unwrap on Bytes and String](./38581-sc-insight-incorrect-unwrap-on-bytes-and-string.md)
+* [37210 - [BC - Insight] Missing Check of HTTP Batch Response Length](./37210-bc-insight-missing-check-of-http-batch-response-length.md)
+* [37350 - [BC - Insight] \`null\` Is Not Unmarshalled Correctly Into json.RawMessage](./37350-bc-insight-null-is-not-unmarshalled-correctly-into-json.rawmessage.md)
+* [37104 - [BC - Insight] Reth RPC is vulnerable to DNS rebinding attacks](./37104-bc-insight-reth-rpc-is-vulnerable-to-dns-rebinding-attacks.md)
+* [38015 - [BC - Insight] Violation of EIP-2681 in Create Transaction](./38015-bc-insight-violation-of-eip-2681-in-create-transaction.md)
+* [37186 - [BC - Insight] Missing Validation for Fixed-Size bytes Types in ABI Parsing](./37186-bc-insight-missing-validation-for-fixed-size-bytes-types-in-abi-parsing.md)
+* [38319 - [BC - Insight] Edge case difference for GETH and NETHERMIND when calculating memory expansion gas](./38319-bc-insight-edge-case-difference-for-geth-and-nethermind-when-calculating-memory-expansion-gas.md)
+* [37594 - [SC - Insight] Nimbus incorrectly rejects non-minimally encoded snappy data length's due to spec. ambiguity](./37594-sc-insight-nimbus-incorrectly-rejects-non-minimally-encoded-snappy-data-lengths-due-to-spec.-a.md)
+* [37153 - [BC - Insight] Malicious validator can bring down honest nodes](./37153-bc-insight-malicious-validator-can-bring-down-honest-nodes.md)
+* [37577 - [BC - Insight] \`tx.origin\` Usage in Group Management Contract Allows Phishing Attack for Unauthorized Actions](./37577-bc-insight-tx.origin-usage-in-group-management-contract-allows-phishing-attack-for-unauthorize.md)
+* [38693 - [SC - Insight] BytesM to Bytes conversion does not match the reference implementation](./38693-sc-insight-bytesm-to-bytes-conversion-does-not-match-the-reference-implementation.md)
 
 </details>
 
 ## Reports by Type
 
+[Smart Contract](<README.md#smart-contract>)
 <details>
 
 <summary>Smart Contract</summary>
 
-* \#38505 \[SC-Low] IRNode Multi-Evaluation In For List Iter
-* \#38530 \[SC-Low] Incorrectly Eliminated Code With Side Effect In Concat Args
-* \#37985 \[SC-Low] Incorrectly Eliminate Code With Side Effect In Slice Args
-* \#38169 \[SC-Insight] Deferred Evaluation Of \`Default\_Return\_Value\` May Skip Side Effect Execution
-* \#38855 \[SC-Low] Evaluation order is not respected in \`log\` function
-* \#37582 \[SC-Low] Incorrect HexString Parsing Leads To Compilation Error Or Type Confusion
-* \#37583 \[SC-Low] Incorrect For Annotation Parsing
-* \#38292 \[SC-Medium] Incorrect Sqrt Calculation Result
-* \#38682 \[SC-Medium] AugAssign evaluation order causing OOB write within the object
-* \#37286 \[SC-Insight] Elimination of Security Checks in ForkCreator Class
-* \#37634 \[SC-Low] Incorrect Builtin ERC4626 Call Signature
-* \#37584 \[SC-Insight] Nonpayable Not Respected For Internal Function
-* \#38581 \[SC-Insight] Incorrect unwrap on Bytes and String
-* \#37594 \[SC-Insight] Nimbus incorrectly rejects non-minimally encoded snappy data length's due to spec. ambiguity
-* \#38693 \[SC-Insight] BytesM to Bytes conversion does not match the reference implementation
+* [38505 - [SC - Low] IRNode Multi-Evaluation In For List Iter](./38505-sc-low-irnode-multi-evaluation-in-for-list-iter.md)
+* [38530 - [SC - Low] Incorrectly Eliminated Code With Side Effect In Concat Args](./38530-sc-low-incorrectly-eliminated-code-with-side-effect-in-concat-args.md)
+* [37985 - [SC - Low] Incorrectly Eliminate Code With Side Effect In Slice Args](./37985-sc-low-incorrectly-eliminate-code-with-side-effect-in-slice-args.md)
+* [38169 - [SC - Insight] Deferred Evaluation Of \`Default\_Return\_Value\` May Skip Side Effect Execution](./38169-sc-insight-deferred-evaluation-of-default_return_value-may-skip-side-effect-execution.md)
+* [38855 - [SC - Low] Evaluation order is not respected in \`log\` function](./38855-sc-low-evaluation-order-is-not-respected-in-log-function.md)
+* [37582 - [SC - Low] Incorrect HexString Parsing Leads To Compilation Error Or Type Confusion](./37582-sc-low-incorrect-hexstring-parsing-leads-to-compilation-error-or-type-confusion.md)
+* [37583 - [SC - Low] Incorrect For Annotation Parsing](./37583-sc-low-incorrect-for-annotation-parsing.md)
+* [38292 - [SC - Medium] Incorrect Sqrt Calculation Result](./38292-sc-medium-incorrect-sqrt-calculation-result.md)
+* [38682 - [SC - Medium] AugAssign evaluation order causing OOB write within the object](./38682-sc-medium-augassign-evaluation-order-causing-oob-write-within-the-object.md)
+* [37286 - [SC - Insight] Elimination of Security Checks in ForkCreator Class](./37286-sc-insight-elimination-of-security-checks-in-forkcreator-class.md)
+* [37634 - [SC - Low] Incorrect Builtin ERC4626 Call Signature](./37634-sc-low-incorrect-builtin-erc4626-call-signature.md)
+* [37584 - [SC - Insight] Nonpayable Not Respected For Internal Function](./37584-sc-insight-nonpayable-not-respected-for-internal-function.md)
+* [38581 - [SC - Insight] Incorrect unwrap on Bytes and String](./38581-sc-insight-incorrect-unwrap-on-bytes-and-string.md)
+* [37594 - [SC - Insight] Nimbus incorrectly rejects non-minimally encoded snappy data length's due to spec. ambiguity](./37594-sc-insight-nimbus-incorrectly-rejects-non-minimally-encoded-snappy-data-lengths-due-to-spec.-a.md)
+* [38693 - [SC - Insight] BytesM to Bytes conversion does not match the reference implementation](./38693-sc-insight-bytesm-to-bytes-conversion-does-not-match-the-reference-implementation.md)
 
 </details>
 
+[Blockchain/DLT](<README.md#blockchain-dlt>)
 <details>
 
 <summary>Blockchain/DLT</summary>
 
-* \#37646 \[BC-Insight] No implementation of BLOB\_SIDECAR\_SUBNET\_COUNT with no issue and no PR in the GitHub
-* \#38502 \[BC-Low] Pending pool subtraction overflow causes node halt/shutdown
-* \#38554 \[BC-Low] Incorrect Transaction Fee Check in \`SendRawTransaction()\`
-* \#37134 \[BC-Insight] Improper secp256k sanitization
-* \#37695 \[BC-Insight] Executing transaction that has a wrong nonce might triggered a chain split due to mismatch stateroot
-* \#37120 \[BC-Insight] Remote handshake-based TCP/30303 flooding leads to an out-of-memory crash
-* \#37191 \[BC-Insight] Unvalidated Field Names in Tuple ABI Parsing Causes Runtime Panic via reflect.StructOf
-* \#37199 \[BC-Low] Potential Chain Fork Due to Shallow Copy of Byte Slice
-* \#37245 \[BC-Low] lodestar snappy decompression issue
-* \#38686 \[BC-Low] Nodes with trusted peers vulnerable to pending peer flooding and DoS
-* \#37593 \[BC-Insight] Inconsistent Address Collision Check Against Precompile Contracts During Contract Deployment
-* \#38598 \[BC-Insight] GetReceiptsMsg abuse leads to the DoS and/or crash of every EL client in the Ethereum network
-* \#37466 \[BC-Medium] Evil-client OOM crash (fast P2P crash)
-* \#37352 \[BC-Insight] Missing Liveness Check in \`collectTableNodes()\`
-* \#37359 \[BC-Insight] Failure to Generate ABI Binding in Golang
-* \#37351 \[BC-Insight] Resubscribe Deadlocks When Unsubscribing Within An Unblock Channel
-* \#38766 \[BC-Insight] Nil Pointer Dereference Panics in encodePayload() of Blob Tx’s Encoding
-* \#38807 \[BC-Low] DoS any reth node via ban logic exploit
-* \#37442 \[BC-Insight] Potential Address Collision with Precompile Contract During Contract Deployment
-* \#37462 \[BC-Low] Invalid RLP decoding for single bytes
-* \#37483 \[BC-Insight] There is a trace discrepancy for Nethermind when handling EOF from PUSH opcode
-* \#38850 \[BC-Low] Remote P2P OOM Crash (GetBlockHeaders) / Reth
-* \#37505 \[BC-Insight] Remotely spamming 1 byte leads to full peer removal and desync in both execution and consensus clients
-* \#37568 \[BC-Insight] Missing Specification Logic
-* \#38894 \[BC-Low] Missing expiration check for Pong and Neighbors packets and not refreshing the endpoint proof
-* \#38275 \[BC-Low] Evil-client P2P headers-traversal leads to D/DoS and total peer removal
-* \#37300 \[BC-Insight] Incorrect Encoding of Negative \*big.Int Values in MakeTopics
-* \#38277 \[BC-Insight] Potential Out-of-Range Panic in \`UnmarshalJSON()\` of \`HexOrDecimal256\`
-* \#38908 \[BC-Insight] Missing Failed Subcalls in Erigon Tracers When Encountering \`ErrInsufficientBalance\` Error
-* \#38958 \[BC-Low] EELS cant handle overflow gas calculation in modexp precompile
-* \#38828 \[BC-Low] Decode RLP of Legacy Transaction Allows Tailing Bytes
-* \#39018 \[BC-Insight] Rate Limiting Under-Specification and Consequences
-* \#37113 \[BC-Low] A potential out-of-range panic has been discovered in the Ethereum client Erigon ( https://github.com/erigontech/erigon ), though it does not seem to be exploitable at this moment du...
-* \#38459 \[BC-Low] erigon remote DoS
-* \#37246 \[BC-Low] lodestar snappy checksum issue
-* \#38733 \[BC-Medium] nibmus-eth2 remote crash
-* \#38920 \[BC-Medium] teku remote DoS
-* \#37148 \[BC-Insight] \`wantedPeerDials()\` branch will never be executed
-* \#38557 \[BC-Insight] Function \`IsPush()\` Misses Opcode PUSH0
-* \#38427 \[BC-Low] Discrepancy in Intrinsic Gas Calculation between Txpool and EVM Execution
-* \#37210 \[BC-Insight] Missing Check of HTTP Batch Response Length
-* \#38902 \[BC-Low] No check on the maximum size of the encoded ENR on ENR\_RESPONSE packet
-* \#37350 \[BC-Insight] \`null\` Is Not Unmarshalled Correctly Into json.RawMessage
-* \#37104 \[BC-Insight] Reth RPC is vulnerable to DNS rebinding attacks
-* \#38948 \[BC-Low] lighthouse remote DoS
-* \#38015 \[BC-Insight] Violation of EIP-2681 in Create Transaction
-* \#37186 \[BC-Insight] Missing Validation for Fixed-Size bytes Types in ABI Parsing
-* \#38319 \[BC-Insight] Edge case difference for GETH and NETHERMIND when calculating memory expansion gas
-* \#37153 \[BC-Insight] Malicious validator can bring down honest nodes
-* \#38278 \[BC-Low] Potential DoS to Mempool Due to Missing Gas Limit Check
-* \#38318 \[BC-Low] nimbus-eth2: Gossipsub misconfiguration allows malicious peers gossip malformed data without penalization
-* \#37577 \[BC-Insight] \`tx.origin\` Usage in Group Management Contract Allows Phishing Attack for Unauthorized Actions
-* \#38146 \[BC-Medium] nimbus-eth2 remote crash
+* [37646 - [BC - Insight] No implementation of BLOB\_SIDECAR\_SUBNET\_COUNT with no issue and no PR in the GitHub](./37646-bc-insight-no-implementation-of-blob_sidecar_subnet_count-with-no-issue-and-no-pr-in-the-githu.md)
+* [38502 - [BC - Low] Pending pool subtraction overflow causes node halt/shutdown](./38502-bc-low-pending-pool-subtraction-overflow-causes-node-halt-shutdown.md)
+* [38554 - [BC - Low] Incorrect Transaction Fee Check in \`SendRawTransaction()\`](./38554-bc-low-incorrect-transaction-fee-check-in-sendrawtransaction.md)
+* [37134 - [BC - Insight] Improper secp256k sanitization](./37134-bc-insight-improper-secp256k-sanitization.md)
+* [37695 - [BC - Insight] Executing transaction that has a wrong nonce might triggered a chain split due to mismatch stateroot](./37695-bc-insight-executing-transaction-that-has-a-wrong-nonce-might-triggered-a-chain-split-due-to-m.md)
+* [37120 - [BC - Insight] Remote handshake-based TCP/30303 flooding leads to an out-of-memory crash](./37120-bc-insight-remote-handshake-based-tcp-30303-flooding-leads-to-an-out-of-memory-crash.md)
+* [37191 - [BC - Insight] Unvalidated Field Names in Tuple ABI Parsing Causes Runtime Panic via reflect.StructOf](./37191-bc-insight-unvalidated-field-names-in-tuple-abi-parsing-causes-runtime-panic-via-reflect.struc.md)
+* [37199 - [BC - Low] Potential Chain Fork Due to Shallow Copy of Byte Slice](./37199-bc-low-potential-chain-fork-due-to-shallow-copy-of-byte-slice.md)
+* [37245 - [BC - Low] lodestar snappy decompression issue](./37245-bc-low-lodestar-snappy-decompression-issue.md)
+* [38686 - [BC - Low] Nodes with trusted peers vulnerable to pending peer flooding and DoS](./38686-bc-low-nodes-with-trusted-peers-vulnerable-to-pending-peer-flooding-and-dos.md)
+* [37593 - [BC - Insight] Inconsistent Address Collision Check Against Precompile Contracts During Contract Deployment](./37593-bc-insight-inconsistent-address-collision-check-against-precompile-contracts-during-contract-d.md)
+* [38598 - [BC - Insight] GetReceiptsMsg abuse leads to the DoS and/or crash of every EL client in the Ethereum network](./38598-bc-insight-getreceiptsmsg-abuse-leads-to-the-dos-and-or-crash-of-every-el-client-in-the-ethere.md)
+* [37466 - [BC - Medium] Evil-client OOM crash (fast P2P crash)](./37466-bc-medium-evil-client-oom-crash-fast-p2p-crash.md)
+* [37352 - [BC - Insight] Missing Liveness Check in \`collectTableNodes()\`](./37352-bc-insight-missing-liveness-check-in-collecttablenodes.md)
+* [37359 - [BC - Insight] Failure to Generate ABI Binding in Golang](./37359-bc-insight-failure-to-generate-abi-binding-in-golang.md)
+* [37351 - [BC - Insight] Resubscribe Deadlocks When Unsubscribing Within An Unblock Channel](./37351-bc-insight-resubscribe-deadlocks-when-unsubscribing-within-an-unblock-channel.md)
+* [38766 - [BC - Insight] Nil Pointer Dereference Panics in encodePayload() of Blob Tx’s Encoding](./38766-bc-insight-nil-pointer-dereference-panics-in-encodepayload-of-blob-txs-encoding.md)
+* [38807 - [BC - Low] DoS any reth node via ban logic exploit](./38807-bc-low-dos-any-reth-node-via-ban-logic-exploit.md)
+* [37442 - [BC - Insight] Potential Address Collision with Precompile Contract During Contract Deployment](./37442-bc-insight-potential-address-collision-with-precompile-contract-during-contract-deployment.md)
+* [37462 - [BC - Low] Invalid RLP decoding for single bytes](./37462-bc-low-invalid-rlp-decoding-for-single-bytes.md)
+* [37483 - [BC - Insight] There is a trace discrepancy for Nethermind when handling EOF from PUSH opcode](./37483-bc-insight-there-is-a-trace-discrepancy-for-nethermind-when-handling-eof-from-push-opcode.md)
+* [38850 - [BC - Low] Remote P2P OOM Crash (GetBlockHeaders) / Reth](./38850-bc-low-remote-p2p-oom-crash-getblockheaders-reth.md)
+* [37505 - [BC - Insight] Remotely spamming 1 byte leads to full peer removal and desync in both execution and consensus clients](./37505-bc-insight-remotely-spamming-1-byte-leads-to-full-peer-removal-and-desync-in-both-execution-an.md)
+* [37568 - [BC - Insight] Missing Specification Logic](./37568-bc-insight-missing-specification-logic.md)
+* [38894 - [BC - Low] Missing expiration check for Pong and Neighbors packets and not refreshing the endpoint proof](./38894-bc-low-missing-expiration-check-for-pong-and-neighbors-packets-and-not-refreshing-the-endpoint.md)
+* [38275 - [BC - Low] Evil-client P2P headers-traversal leads to D/DoS and total peer removal](./38275-bc-low-evil-client-p2p-headers-traversal-leads-to-d-dos-and-total-peer-removal.md)
+* [37300 - [BC - Insight] Incorrect Encoding of Negative \*big.Int Values in MakeTopics](./37300-bc-insight-incorrect-encoding-of-negative-big.int-values-in-maketopics.md)
+* [38277 - [BC - Insight] Potential Out-of-Range Panic in \`UnmarshalJSON()\` of \`HexOrDecimal256\`](./38277-bc-insight-potential-out-of-range-panic-in-unmarshaljson-of-hexordecimal256.md)
+* [38908 - [BC - Insight] Missing Failed Subcalls in Erigon Tracers When Encountering \`ErrInsufficientBalance\` Error](./38908-bc-insight-missing-failed-subcalls-in-erigon-tracers-when-encountering-errinsufficientbalance.md)
+* [38958 - [BC - Low] EELS cant handle overflow gas calculation in modexp precompile](./38958-bc-low-eels-cant-handle-overflow-gas-calculation-in-modexp-precompile.md)
+* [38828 - [BC - Low] Decode RLP of Legacy Transaction Allows Tailing Bytes](./38828-bc-low-decode-rlp-of-legacy-transaction-allows-tailing-bytes.md)
+* [39018 - [BC - Insight] Rate Limiting Under-Specification and Consequences](./39018-bc-insight-rate-limiting-under-specification-and-consequences.md)
+<!-- * [37113 - [BC - Low] A potential out-of-range panic has been discovered in the Ethereum client Erigon ( https://github.com/erigontech/erigon ), though it does not seem to be exploitable at this moment du...]() -->
+<!-- * [38459 - [BC - Low] erigon remote DoS]() -->
+* [37246 - [BC - Low] lodestar snappy checksum issue](./37246-bc-low-lodestar-snappy-checksum-issue.md)
+* [38733 - [BC - Medium] nibmus-eth2 remote crash](./38733-bc-medium-nibmus-eth2-remote-crash.md)
+* [38920 - [BC - Medium] teku remote DoS](./38920-bc-medium-teku-remote-dos.md)
+* [37148 - [BC - Insight] \`wantedPeerDials()\` branch will never be executed](./37148-bc-insight-wantedpeerdials-branch-will-never-be-executed.md)
+* [38557 - [BC - Insight] Function \`IsPush()\` Misses Opcode PUSH0](./38557-bc-insight-function-ispush-misses-opcode-push0.md)
+* [38427 - [BC - Low] Discrepancy in Intrinsic Gas Calculation between Txpool and EVM Execution](./38427-bc-low-discrepancy-in-intrinsic-gas-calculation-between-txpool-and-evm-execution.md)
+* [37210 - [BC - Insight] Missing Check of HTTP Batch Response Length](./37210-bc-insight-missing-check-of-http-batch-response-length.md)
+* [38902 - [BC - Low] No check on the maximum size of the encoded ENR on ENR\_RESPONSE packet](./38902-bc-low-no-check-on-the-maximum-size-of-the-encoded-enr-on-enr_response-packet.md)
+* [37350 - [BC - Insight] \`null\` Is Not Unmarshalled Correctly Into json.RawMessage](./37350-bc-insight-null-is-not-unmarshalled-correctly-into-json.rawmessage.md)
+* [37104 - [BC - Insight] Reth RPC is vulnerable to DNS rebinding attacks](./37104-bc-insight-reth-rpc-is-vulnerable-to-dns-rebinding-attacks.md)
+* [38948 - [BC - Low] lighthouse remote DoS](./38948-bc-low-lighthouse-remote-dos.md)
+* [38015 - [BC - Insight] Violation of EIP-2681 in Create Transaction](./38015-bc-insight-violation-of-eip-2681-in-create-transaction.md)
+* [37186 - [BC - Insight] Missing Validation for Fixed-Size bytes Types in ABI Parsing](./37186-bc-insight-missing-validation-for-fixed-size-bytes-types-in-abi-parsing.md)
+* [38319 - [BC - Insight] Edge case difference for GETH and NETHERMIND when calculating memory expansion gas](./38319-bc-insight-edge-case-difference-for-geth-and-nethermind-when-calculating-memory-expansion-gas.md)
+* [37153 - [BC - Insight] Malicious validator can bring down honest nodes](./37153-bc-insight-malicious-validator-can-bring-down-honest-nodes.md)
+* [38278 - [BC - Low] Potential DoS to Mempool Due to Missing Gas Limit Check](./38278-bc-low-potential-dos-to-mempool-due-to-missing-gas-limit-check.md)
+* [38318 - [BC - Low] nimbus-eth2: Gossipsub misconfiguration allows malicious peers gossip malformed data without penalization](./38318-bc-low-nimbus-eth2-gossipsub-misconfiguration-allows-malicious-peers-gossip-malformed-data-wit.md)
+* [37577 - [BC - Insight] \`tx.origin\` Usage in Group Management Contract Allows Phishing Attack for Unauthorized Actions](./37577-bc-insight-tx.origin-usage-in-group-management-contract-allows-phishing-attack-for-unauthorize.md)
+* [38146 - [BC - Medium] nimbus-eth2 remote crash](./38146-bc-medium-nimbus-eth2-remote-crash.md)
 
 </details>

--- a/fluid-protocol/README.md
+++ b/fluid-protocol/README.md
@@ -2,14 +2,15 @@
 
 ## Reports by Severity
 
+[Critical](<README.md#critical>) | [Medium](<README.md#medium>) | [Low](<README.md#low>) | [Insight](<README.md#insight>)
 <details>
 
 <summary>Critical</summary>
 
-* \#37671 \[SC-Critical] CRITICAL-02 / The contract could be permanently locked due to not reseting the boolen lock
-* \#37323 \[SC-Critical] Permanent dead Lock in internal\_redeem\_collateral\_from\_trove
-* \#37452 \[SC-Critical] \`trove-manager-contract.redeem\_collateral\_from\_trove\` can be locked forever
-* \#37624 \[SC-Critical] Lock Issue Bricks The Redeem Functionality
+* [37671 - [SC - Critical] CRITICAL-02 / The contract could be permanently locked due to not reseting the boolen lock](./37671-sc-critical-critical-02-the-contract-could-be-permanently-locked-due-to-not-reseting-the-boole.md)
+* [37323 - [SC - Critical] Permanent dead Lock in internal\_redeem\_collateral\_from\_trove](./37323-sc-critical-permanent-dead-lock-in-internal_redeem_collateral_from_trove.md)
+* [37452 - [SC - Critical] \`trove-manager-contract.redeem\_collateral\_from\_trove\` can be locked forever](./37452-sc-critical-trove-manager-contract.redeem_collateral_from_trove-can-be-locked-forever.md)
+* [37624 - [SC - Critical] Lock Issue Bricks The Redeem Functionality](./37624-sc-critical-lock-issue-bricks-the-redeem-functionality.md)
 
 </details>
 
@@ -17,7 +18,7 @@
 
 <summary>Medium</summary>
 
-* \#37276 \[SC-Medium] Redstone's price feed is used incorrectly.
+* [37276 - [SC - Medium] Redstone's price feed is used incorrectly.](./37276-sc-medium-redstones-price-feed-is-used-incorrectly..md)
 
 </details>
 
@@ -25,13 +26,13 @@
 
 <summary>Low</summary>
 
-* \#37668 \[SC-Low] Incorrect Scale Factor value leads to early scale change
-* \#37650 \[SC-Low] Redeem Functionality Partially Failing
-* \#37354 \[SC-Low] Single below MCR trove temporarily blocks redemptions
-* \#37283 \[SC-Low] Improper Trove Validation Check Allows Low-Cost Griefing Attack to Block Protocol Redemptions
-* \#37192 \[SC-Low] Trove that under MCR might be redeemed.
-* \#37409 \[SC-Low] Can not redeem when all \`current\_cr\` less than \`MCR\`.
-* \#37607 \[SC-Low] Bricking Redeem Function
+* [37668 - [SC - Low] Incorrect Scale Factor value leads to early scale change](./37668-sc-low-incorrect-scale-factor-value-leads-to-early-scale-change.md)
+* [37650 - [SC - Low] Redeem Functionality Partially Failing](./37650-sc-low-redeem-functionality-partially-failing.md)
+* [37354 - [SC - Low] Single below MCR trove temporarily blocks redemptions](./37354-sc-low-single-below-mcr-trove-temporarily-blocks-redemptions.md)
+* [37283 - [SC - Low] Improper Trove Validation Check Allows Low-Cost Griefing Attack to Block Protocol Redemptions](./37283-sc-low-improper-trove-validation-check-allows-low-cost-griefing-attack-to-block-protocol-redem.md)
+* [37192 - [SC - Low] Trove that under MCR might be redeemed.](./37192-sc-low-trove-that-under-mcr-might-be-redeemed..md)
+* [37409 - [SC - Low] Can not redeem when all \`current\_cr\` less than \`MCR\`.](./37409-sc-low-can-not-redeem-when-all-current_cr-less-than-mcr-..md)
+* [37607 - [SC - Low] Bricking Redeem Function](./37607-sc-low-bricking-redeem-function.md)
 
 </details>
 
@@ -39,42 +40,43 @@
 
 <summary>Insight</summary>
 
-* \#36922 \[SC-Insight] the function claim\_collateral in borrowOperation have read only attribute while the invoked claim\_collateral function have write attribute, this lead to compiler-time error
-* \#37139 \[SC-Insight] INSIGHT: Inefficient Use of Storage Reentrancy Locks
-* \#37056 \[SC-Insight] \`require\_at\_least\_min\_net\_debt\` did not emit correct error message
-* \#37202 \[SC-Insight] some checks can be removed since its not required(best practice report, not an issue)
-* \#37343 \[SC-Insight] Inaccurate Check Leading to Debt Miscalculation
-* \#37382 \[SC-Insight] Inconsistent Collateral Ratio Checks in Stability Pool Withdrawals Lead to Fund-Locking DoS
-* \#37425 \[SC-Insight] redeem\_collateral does not redeem collateral from riskiest trove but wrongly redeem lowest healthy troves with lowest collateral Ratio
-* \#37595 \[SC-Insight] \`require\_caller\_is\_bo\_or\_tm\_or\_sp\_or\_pm\` did not emit correct message
+* [36922 - [SC - Insight] the function claim\_collateral in borrowOperation have read only attribute while the invoked claim\_collateral function have write attribute, this lead to compiler-time error](./36922-sc-insight-the-function-claim_collateral-in-borrowoperation-have-read-only-attribute-while-the.md)
+* [37139 - [SC - Insight] INSIGHT: Inefficient Use of Storage Reentrancy Locks](./37139-sc-insight-insight-inefficient-use-of-storage-reentrancy-locks.md)
+* [37056 - [SC - Insight] \`require\_at\_least\_min\_net\_debt\` did not emit correct error message](./37056-sc-insight-require_at_least_min_net_debt-did-not-emit-correct-error-message.md)
+* [37202 - [SC - Insight] some checks can be removed since its not required(best practice report, not an issue)](./37202-sc-insight-some-checks-can-be-removed-since-its-not-required-best-practice-report-not-an-issue.md)
+* [37343 - [SC - Insight] Inaccurate Check Leading to Debt Miscalculation](./37343-sc-insight-inaccurate-check-leading-to-debt-miscalculation.md)
+* [37382 - [SC - Insight] Inconsistent Collateral Ratio Checks in Stability Pool Withdrawals Lead to Fund-Locking DoS](./37382-sc-insight-inconsistent-collateral-ratio-checks-in-stability-pool-withdrawals-lead-to-fund-loc.md)
+* [37425 - [SC - Insight] redeem\_collateral does not redeem collateral from riskiest trove but wrongly redeem lowest healthy troves with lowest collateral Ratio](./37425-sc-insight-redeem-collateral-does-not-redeem-collateral-from-riskiest-trove-but-wrongly-redeem.md)
+* [37595 - [SC - Insight] \`require\_caller\_is\_bo\_or\_tm\_or\_sp\_or\_pm\` did not emit correct message](./37595-sc-insight-require_caller_is_bo_or_tm_or_sp_or_pm-did-not-emit-correct-message.md)
 
 </details>
 
 ## Reports by Type
 
+[Smart Contract](<README.md#smart-contract>)
 <details>
 
 <summary>Smart Contract</summary>
 
-* \#37668 \[SC-Low] Incorrect Scale Factor value leads to early scale change
-* \#37650 \[SC-Low] Redeem Functionality Partially Failing
-* \#37276 \[SC-Medium] Redstone's price feed is used incorrectly.
-* \#36922 \[SC-Insight] the function claim\_collateral in borrowOperation have read only attribute while the invoked claim\_collateral function have write attribute, this lead to compiler-time error
-* \#37139 \[SC-Insight] INSIGHT: Inefficient Use of Storage Reentrancy Locks
-* \#37354 \[SC-Low] Single below MCR trove temporarily blocks redemptions
-* \#37671 \[SC-Critical] CRITICAL-02 / The contract could be permanently locked due to not reseting the boolen lock
-* \#37056 \[SC-Insight] \`require\_at\_least\_min\_net\_debt\` did not emit correct error message
-* \#37202 \[SC-Insight] some checks can be removed since its not required(best practice report, not an issue)
-* \#37283 \[SC-Low] Improper Trove Validation Check Allows Low-Cost Griefing Attack to Block Protocol Redemptions
-* \#37323 \[SC-Critical] Permanent dead Lock in internal\_redeem\_collateral\_from\_trove
-* \#37343 \[SC-Insight] Inaccurate Check Leading to Debt Miscalculation
-* \#37382 \[SC-Insight] Inconsistent Collateral Ratio Checks in Stability Pool Withdrawals Lead to Fund-Locking DoS
-* \#37192 \[SC-Low] Trove that under MCR might be redeemed.
-* \#37425 \[SC-Insight] redeem\_collateral does not redeem collateral from riskiest trove but wrongly redeem lowest healthy troves with lowest collateral Ratio
-* \#37409 \[SC-Low] Can not redeem when all \`current\_cr\` less than \`MCR\`.
-* \#37452 \[SC-Critical] \`trove-manager-contract.redeem\_collateral\_from\_trove\` can be locked forever
-* \#37595 \[SC-Insight] \`require\_caller\_is\_bo\_or\_tm\_or\_sp\_or\_pm\` did not emit correct message
-* \#37607 \[SC-Low] Bricking Redeem Function
-* \#37624 \[SC-Critical] Lock Issue Bricks The Redeem Functionality
+* [37668 - [SC - Low] Incorrect Scale Factor value leads to early scale change](./37668-sc-low-incorrect-scale-factor-value-leads-to-early-scale-change.md)
+* [37650 - [SC - Low] Redeem Functionality Partially Failing](./37650-sc-low-redeem-functionality-partially-failing.md)
+* [37276 - [SC - Medium] Redstone's price feed is used incorrectly.](./37276-sc-medium-redstones-price-feed-is-used-incorrectly..md)
+* [36922 - [SC - Insight] the function claim\_collateral in borrowOperation have read only attribute while the invoked claim\_collateral function have write attribute, this lead to compiler-time error](./36922-sc-insight-the-function-claim_collateral-in-borrowoperation-have-read-only-attribute-while-the.md)
+* [37139 - [SC - Insight] INSIGHT: Inefficient Use of Storage Reentrancy Locks](./37139-sc-insight-insight-inefficient-use-of-storage-reentrancy-locks.md)
+* [37354 - [SC - Low] Single below MCR trove temporarily blocks redemptions](./37354-sc-low-single-below-mcr-trove-temporarily-blocks-redemptions.md)
+* [37671 - [SC - Critical] CRITICAL-02 / The contract could be permanently locked due to not reseting the boolen lock](./37671-sc-critical-critical-02-the-contract-could-be-permanently-locked-due-to-not-reseting-the-boole.md)
+* [37056 - [SC - Insight] \`require\_at\_least\_min\_net\_debt\` did not emit correct error message](./37056-sc-insight-require_at_least_min_net_debt-did-not-emit-correct-error-message.md)
+* [37202 - [SC - Insight] some checks can be removed since its not required(best practice report, not an issue)](./37202-sc-insight-some-checks-can-be-removed-since-its-not-required-best-practice-report-not-an-issue.md)
+* [37283 - [SC - Low] Improper Trove Validation Check Allows Low-Cost Griefing Attack to Block Protocol Redemptions](./37283-sc-low-improper-trove-validation-check-allows-low-cost-griefing-attack-to-block-protocol-redem.md)
+* [37323 - [SC - Critical] Permanent dead Lock in internal\_redeem\_collateral\_from\_trove](./37323-sc-critical-permanent-dead-lock-in-internal_redeem_collateral_from_trove.md)
+* [37343 - [SC - Insight] Inaccurate Check Leading to Debt Miscalculation](./37343-sc-insight-inaccurate-check-leading-to-debt-miscalculation.md)
+* [37382 - [SC - Insight] Inconsistent Collateral Ratio Checks in Stability Pool Withdrawals Lead to Fund-Locking DoS](./37382-sc-insight-inconsistent-collateral-ratio-checks-in-stability-pool-withdrawals-lead-to-fund-loc.md)
+* [37192 - [SC - Low] Trove that under MCR might be redeemed.](./37192-sc-low-trove-that-under-mcr-might-be-redeemed..md)
+* [37425 - [SC - Insight] redeem\_collateral does not redeem collateral from riskiest trove but wrongly redeem lowest healthy troves with lowest collateral Ratio](./37425-sc-insight-redeem-collateral-does-not-redeem-collateral-from-riskiest-trove-but-wrongly-redeem.md)
+* [37409 - [SC - Low] Can not redeem when all \`current\_cr\` less than \`MCR\`.](./37409-sc-low-can-not-redeem-when-all-current_cr-less-than-mcr-..md)
+* [37452 - [SC - Critical] \`trove-manager-contract.redeem\_collateral\_from\_trove\` can be locked forever](./37452-sc-critical-trove-manager-contract.redeem_collateral_from_trove-can-be-locked-forever.md)
+* [37595 - [SC - Insight] \`require\_caller\_is\_bo\_or\_tm\_or\_sp\_or\_pm\` did not emit correct message](./37595-sc-insight-require_caller_is_bo_or_tm_or_sp_or_pm-did-not-emit-correct-message.md)
+* [37607 - [SC - Low] Bricking Redeem Function](./37607-sc-low-bricking-redeem-function.md)
+* [37624 - [SC - Critical] Lock Issue Bricks The Redeem Functionality](./37624-sc-critical-lock-issue-bricks-the-redeem-functionality.md)
 
 </details>

--- a/folks-liquid-staking/README.md
+++ b/folks-liquid-staking/README.md
@@ -2,18 +2,19 @@
 
 ## Reports by Severity
 
+[High](<README.md#high>) | [Insight](<README.md#insight>)
 <details>
 
 <summary>High</summary>
 
-* \#37660 \[SC-High] incorrect tracking of \`TOTAL\_ACTIVE\_STAKE\` leads to permanent freezing of funds
-* \#37775 \[SC-High] Accounting Discrepancy in \`consensus\_v2.py::burn()\`can potentially cause underflow and lead to temporary Denial of Service and a deliberate DOS Attack
-* \#37852 \[SC-High] The accumulation of rewards is being decreased from the active stake which could leave out users unable to redeem xAlgo
-* \#37863 \[SC-High] Underflow in burn method prevents all xALGO from being burnt
-* \#37889 \[SC-High] Underflow in \`burn()\` function will cause user funds to partially frozen
-* \#37940 \[SC-High] Freezing of user funds When Reward accumulated or added
-* \#37903 \[SC-High] "Potential Underflow Vulnerability in burn Function for total\_active\_stake\_key"
-* \#37661 \[SC-High] Incorrect \`total\_active\_stake\` reduction causes loss of funds for the users and excessive fees collection over time
+* [37660 - [SC - High] incorrect tracking of \`TOTAL\_ACTIVE\_STAKE\` leads to permanent freezing of funds](./37660-sc-high-incorrect-tracking-of-total_active_stake-leads-to-permanent-freezing-of-funds.md)
+* [37775 - [SC - High] Accounting Discrepancy in \`consensus\_v2.py::burn()\`can potentially cause underflow and lead to temporary Denial of Service and a deliberate DOS Attack](./37775-sc-high-accounting-discrepancy-in-consensus_v2.py-burn-can-potentially-cause-underflow-and-lea.md)
+* [37852 - [SC - High] The accumulation of rewards is being decreased from the active stake which could leave out users unable to redeem xAlgo](./37852-sc-high-the-accumulation-of-rewards-is-being-decreased-from-the-active-stake-which-could-leave.md)
+* [37863 - [SC - High] Underflow in burn method prevents all xALGO from being burnt](./37863-sc-high-underflow-in-burn-method-prevents-all-xalgo-from-being-burnt.md)
+* [37889 - [SC - High] Underflow in \`burn()\` function will cause user funds to partially frozen](./37889-sc-high-underflow-in-burn-function-will-cause-user-funds-to-partially-frozen.md)
+* [37940 - [SC - High] Freezing of user funds When Reward accumulated or added](./37940-sc-high-freezing-of-user-funds-when-reward-accumulated-or-added.md)
+* [37903 - [SC - High] "Potential Underflow Vulnerability in burn Function for total\_active\_stake\_key"](./37903-sc-high-potential-underflow-vulnerability-in-burn-function-for-total_active_stake_key.md)
+* [37661 - [SC - High] Incorrect \`total\_active\_stake\` reduction causes loss of funds for the users and excessive fees collection over time](./37661-sc-high-incorrect-total_active_stake-reduction-causes-loss-of-funds-for-the-users-and-excessiv.md)
 
 </details>
 
@@ -21,7 +22,7 @@
 
 <summary>Low</summary>
 
-* \#37867 \[SC-Low] Contract upgrade failing due to SHA256 failing because of AVM byte width limits
+* [37867 - [SC - Low] Contract upgrade failing due to SHA256 failing because of AVM byte width limits](./37867-sc-low-contract-upgrade-failing-due-to-sha256-failing-because-of-avm-byte-width-limits.md)
 
 </details>
 
@@ -29,35 +30,36 @@
 
 <summary>Insight</summary>
 
-* \#37768 \[SC-Insight] Missing Event Emission when proposer are added prevents safe retrieval of index for subsequent operations
-* \#37807 \[SC-Insight] Truncation of mint\_amount to zero leading to potential stake loss
-* \#37854 \[SC-Insight] Missing state validation upon Upgrade
-* \#37893 \[SC-Insight] Inflation Attack in xAlgo
-* \#37864 \[SC-Insight] Over-charging users on delayed mint
-* \#37791 \[SC-Insight] Consensus contract distributes Algo for proposers that are offline that cause losing of reward
+* [37768 - [SC - Insight] Missing Event Emission when proposer are added prevents safe retrieval of index for subsequent operations](./37768-sc-insight-missing-event-emission-when-proposer-are-added-prevents-safe-retrieval-of-index-for.md)
+* [37807 - [SC - Insight] Truncation of mint\_amount to zero leading to potential stake loss](./37807-sc-insight-truncation-of-mint_amount-to-zero-leading-to-potential-stake-loss.md)
+* [37854 - [SC - Insight] Missing state validation upon Upgrade](./37854-sc-insight-missing-state-validation-upon-upgrade.md)
+* [37893 - [SC - Insight] Inflation Attack in xAlgo](./37893-sc-insight-inflation-attack-in-xalgo.md)
+* [37864 - [SC - Insight] Over-charging users on delayed mint](./37864-sc-insight-over-charging-users-on-delayed-mint.md)
+* [37791 - [SC - Insight] Consensus contract distributes Algo for proposers that are offline that cause losing of reward](./37791-sc-insight-consensus-contract-distributes-algo-for-proposers-that-are-offline-that-cause-losin.md)
 
 </details>
 
 ## Reports by Type
 
+[Smart Contract](<README.md#smart-contract>)
 <details>
 
 <summary>Smart Contract</summary>
 
-* \#37660 \[SC-High] incorrect tracking of \`TOTAL\_ACTIVE\_STAKE\` leads to permanent freezing of funds
-* \#37768 \[SC-Insight] Missing Event Emission when proposer are added prevents safe retrieval of index for subsequent operations
-* \#37775 \[SC-High] Accounting Discrepancy in \`consensus\_v2.py::burn()\`can potentially cause underflow and lead to temporary Denial of Service and a deliberate DOS Attack
-* \#37807 \[SC-Insight] Truncation of mint\_amount to zero leading to potential stake loss
-* \#37852 \[SC-High] The accumulation of rewards is being decreased from the active stake which could leave out users unable to redeem xAlgo
-* \#37854 \[SC-Insight] Missing state validation upon Upgrade
-* \#37863 \[SC-High] Underflow in burn method prevents all xALGO from being burnt
-* \#37889 \[SC-High] Underflow in \`burn()\` function will cause user funds to partially frozen
-* \#37893 \[SC-Insight] Inflation Attack in xAlgo
-* \#37940 \[SC-High] Freezing of user funds When Reward accumulated or added
-* \#37867 \[SC-Low] Contract upgrade failing due to SHA256 failing because of AVM byte width limits
-* \#37903 \[SC-High] "Potential Underflow Vulnerability in burn Function for total\_active\_stake\_key"
-* \#37864 \[SC-Insight] Over-charging users on delayed mint
-* \#37661 \[SC-High] Incorrect \`total\_active\_stake\` reduction causes loss of funds for the users and excessive fees collection over time
-* \#37791 \[SC-Insight] Consensus contract distributes Algo for proposers that are offline that cause losing of reward
+* [37660 - [SC - High] incorrect tracking of \`TOTAL\_ACTIVE\_STAKE\` leads to permanent freezing of funds](./37660-sc-high-incorrect-tracking-of-total_active_stake-leads-to-permanent-freezing-of-funds.md)
+* [37768 - [SC - Insight] Missing Event Emission when proposer are added prevents safe retrieval of index for subsequent operations](./37768-sc-insight-missing-event-emission-when-proposer-are-added-prevents-safe-retrieval-of-index-for.md)
+* [37775 - [SC - High] Accounting Discrepancy in \`consensus\_v2.py::burn()\`can potentially cause underflow and lead to temporary Denial of Service and a deliberate DOS Attack](./37775-sc-high-accounting-discrepancy-in-consensus_v2.py-burn-can-potentially-cause-underflow-and-lea.md)
+* [37807 - [SC - Insight] Truncation of mint\_amount to zero leading to potential stake loss](./37807-sc-insight-truncation-of-mint_amount-to-zero-leading-to-potential-stake-loss.md)
+* [37852 - [SC - High] The accumulation of rewards is being decreased from the active stake which could leave out users unable to redeem xAlgo](./37852-sc-high-the-accumulation-of-rewards-is-being-decreased-from-the-active-stake-which-could-leave.md)
+* [37854 - [SC - Insight] Missing state validation upon Upgrade](./37854-sc-insight-missing-state-validation-upon-upgrade.md)
+* [37863 - [SC - High] Underflow in burn method prevents all xALGO from being burnt](./37863-sc-high-underflow-in-burn-method-prevents-all-xalgo-from-being-burnt.md)
+* [37889 - [SC - High] Underflow in \`burn()\` function will cause user funds to partially frozen](./37889-sc-high-underflow-in-burn-function-will-cause-user-funds-to-partially-frozen.md)
+* [37893 - [SC - Insight] Inflation Attack in xAlgo](./37893-sc-insight-inflation-attack-in-xalgo.md)
+* [37940 - [SC - High] Freezing of user funds When Reward accumulated or added](./37940-sc-high-freezing-of-user-funds-when-reward-accumulated-or-added.md)
+* [37867 - [SC - Low] Contract upgrade failing due to SHA256 failing because of AVM byte width limits](./37867-sc-low-contract-upgrade-failing-due-to-sha256-failing-because-of-avm-byte-width-limits.md)
+* [37903 - [SC - High] "Potential Underflow Vulnerability in burn Function for total\_active\_stake\_key"](./37903-sc-high-potential-underflow-vulnerability-in-burn-function-for-total_active_stake_key.md)
+* [37864 - [SC - Insight] Over-charging users on delayed mint](./37864-sc-insight-over-charging-users-on-delayed-mint.md)
+* [37661 - [SC - High] Incorrect \`total\_active\_stake\` reduction causes loss of funds for the users and excessive fees collection over time](./37661-sc-high-incorrect-total_active_stake-reduction-causes-loss-of-funds-for-the-users-and-excessiv.md)
+* [37791 - [SC - Insight] Consensus contract distributes Algo for proposers that are offline that cause losing of reward](./37791-sc-insight-consensus-contract-distributes-algo-for-proposers-that-are-offline-that-cause-losin.md)
 
 </details>

--- a/jito-restaking/README.md
+++ b/jito-restaking/README.md
@@ -2,15 +2,16 @@
 
 ## Reports by Severity
 
+[High](<README.md#high>) | [Insight](<README.md#insight>)
 <details>
 
 <summary>High</summary>
 
-* \#37311 \[SC-High] Attackers can steal rewards by depositing, updating vault balance and withdrawing immediately after a large reward is deposited
-* \#37314 \[SC-High] Vault creators can not withdraw their fees without being recursively charged (vault and program) fees on their own fees which causes permanent loss of funds
-* \#37315 \[SC-High] Theft of Unclaimed Yields Due to Improper Reward Distribution in Vault Program
-* \#37295 \[SC-High] Rewards can be stolen by depositing immediately after reward tokens get sent to vault
-* \#36903 \[SC-High] The vault reward mechanism can be sandwiched by MEV
+* [37311 - [SC - High] Attackers can steal rewards by depositing, updating vault balance and withdrawing immediately after a large reward is deposited](./37311-sc-high-attackers-can-steal-rewards-by-depositing-updating-vault-balance-and-withdrawing-immed.md)
+* [37314 - [SC - High] Vault creators can not withdraw their fees without being recursively charged (vault and program) fees on their own fees which causes permanent loss of funds](./37314-sc-high-vault-creators-can-not-withdraw-their-fees-without-being-recursively-charged-vault-and.md)
+* [37315 - [SC - High] Theft of Unclaimed Yields Due to Improper Reward Distribution in Vault Program](./37315-sc-high-theft-of-unclaimed-yields-due-to-improper-reward-distribution-in-vault-program.md)
+* [37295 - [SC - High] Rewards can be stolen by depositing immediately after reward tokens get sent to vault](./37295-sc-high-rewards-can-be-stolen-by-depositing-immediately-after-reward-tokens-get-sent-to-vault.md)
+* [36903 - [SC - High] The vault reward mechanism can be sandwiched by MEV](./36903-sc-high-the-vault-reward-mechanism-can-be-sandwiched-by-mev.md)
 
 </details>
 
@@ -18,25 +19,26 @@
 
 <summary>Insight</summary>
 
-* \#37079 \[SC-Insight] Withdrawals can be DOSed by reviving tickets in the same burn tx
-* \#36675 \[SC-Insight] Missing revoke instruction leads to Old delegate accounts have unlimited number of token allowance
-* \#36787 \[SC-Insight] The vault program don't support token2022 transfer
+* [37079 - [SC - Insight] Withdrawals can be DOSed by reviving tickets in the same burn tx](./37079-sc-insight-withdrawals-can-be-dosed-by-reviving-tickets-in-the-same-burn-tx.md)
+* [36675 - [SC - Insight] Missing revoke instruction leads to Old delegate accounts have unlimited number of token allowance](./36675-sc-insight-missing-revoke-instruction-leads-to-old-delegate-accounts-have-unlimited-number-of.md)
+* [36787 - [SC - Insight] The vault program don't support token2022 transfer](./36787-sc-insight-the-vault-program-dont-support-token2022-transfer.md)
 
 </details>
 
 ## Reports by Type
 
+[Smart Contract](<README.md#smart-contract>)
 <details>
 
 <summary>Smart Contract</summary>
 
-* \#37079 \[SC-Insight] Withdrawals can be DOSed by reviving tickets in the same burn tx
-* \#36675 \[SC-Insight] Missing revoke instruction leads to Old delegate accounts have unlimited number of token allowance
-* \#37311 \[SC-High] Attackers can steal rewards by depositing, updating vault balance and withdrawing immediately after a large reward is deposited
-* \#37314 \[SC-High] Vault creators can not withdraw their fees without being recursively charged (vault and program) fees on their own fees which causes permanent loss of funds
-* \#37315 \[SC-High] Theft of Unclaimed Yields Due to Improper Reward Distribution in Vault Program
-* \#36787 \[SC-Insight] The vault program don't support token2022 transfer
-* \#37295 \[SC-High] Rewards can be stolen by depositing immediately after reward tokens get sent to vault
-* \#36903 \[SC-High] The vault reward mechanism can be sandwiched by MEV
+* [37079 - [SC - Insight] Withdrawals can be DOSed by reviving tickets in the same burn tx](./37079-sc-insight-withdrawals-can-be-dosed-by-reviving-tickets-in-the-same-burn-tx.md)
+* [36675 - [SC - Insight] Missing revoke instruction leads to Old delegate accounts have unlimited number of token allowance](./36675-sc-insight-missing-revoke-instruction-leads-to-old-delegate-accounts-have-unlimited-number-of.md)
+* [37311 - [SC - High] Attackers can steal rewards by depositing, updating vault balance and withdrawing immediately after a large reward is deposited](./37311-sc-high-attackers-can-steal-rewards-by-depositing-updating-vault-balance-and-withdrawing-immed.md)
+* [37314 - [SC - High] Vault creators can not withdraw their fees without being recursively charged (vault and program) fees on their own fees which causes permanent loss of funds](./37314-sc-high-vault-creators-can-not-withdraw-their-fees-without-being-recursively-charged-vault-and.md)
+* [37315 - [SC - High] Theft of Unclaimed Yields Due to Improper Reward Distribution in Vault Program](./37315-sc-high-theft-of-unclaimed-yields-due-to-improper-reward-distribution-in-vault-program.md)
+* [36787 - [SC - Insight] The vault program don't support token2022 transfer](./36787-sc-insight-the-vault-program-dont-support-token2022-transfer.md)
+* [37295 - [SC - High] Rewards can be stolen by depositing immediately after reward tokens get sent to vault](./37295-sc-high-rewards-can-be-stolen-by-depositing-immediately-after-reward-tokens-get-sent-to-vault.md)
+* [36903 - [SC - High] The vault reward mechanism can be sandwiched by MEV](./36903-sc-high-the-vault-reward-mechanism-can-be-sandwiched-by-mev.md)
 
 </details>

--- a/lombard/README.md
+++ b/lombard/README.md
@@ -2,16 +2,17 @@
 
 ## Reports by Severity
 
+[Medium](<README.md#medium>) | [Low](<README.md#low>) | [Insight](<README.md#insight>)
 <details>
 
 <summary>Medium</summary>
 
-* \#38634 \[SC-Medium] Insufficient validation on offchainTokenData in TokenPool.releaseOrMint allows CCIP message to be executed with mismatched payload potentially leading to loss of funds in cross-ch...
-* \#38066 \[SC-Medium] \`ProxyFactory\` is vulnerable to DoS/Address Hijacking
-* \#38154 \[SC-Medium] The offchain data provided to the CLAdapter isn’t properly validated and can be from a different CCIP message, resulting in the freezing of funds
-* \#38342 \[SC-Medium] Interchanging \`offchainTokenData\` between two valid messages
-* \#38363 \[SC-Medium] LBTC cross-chain transfer can be DOSed
-* \#38335 \[SC-Medium] Attacker can exploit PartnerVault mint small amount to cause LBTC depeg or Protocol Insolvency
+* [38634 - [SC - Medium] Insufficient validation on offchainTokenData in TokenPool.releaseOrMint allows CCIP message to be executed with mismatched payload potentially leading to loss of funds in cross-ch...](./38634-sc-medium-insufficient-validation-on-offchaintokendata-in-tokenpool.releaseormint-allows-ccip.md)
+* [38066 - [SC - Medium] \`ProxyFactory\` is vulnerable to DoS/Address Hijacking](./38066-sc-medium-proxyfactory-is-vulnerable-to-dos-address-hijacking.md)
+* [38154 - [SC - Medium] The offchain data provided to the CLAdapter isn’t properly validated and can be from a different CCIP message, resulting in the freezing of funds](./38154-sc-medium-the-offchain-data-provided-to-the-cladapter-isnt-properly-validated-and-can-be-from.md)
+* [38342 - [SC - Medium] Interchanging \`offchainTokenData\` between two valid messages](./38342-sc-medium-interchanging-offchaintokendata-between-two-valid-messages.md)
+* [38363 - [SC - Medium] LBTC cross-chain transfer can be DOSed](./38363-sc-medium-lbtc-cross-chain-transfer-can-be-dosed.md)
+* [38335 - [SC - Medium] Attacker can exploit PartnerVault mint small amount to cause LBTC depeg or Protocol Insolvency](./38335-sc-medium-attacker-can-exploit-partnervault-mint-small-amount-to-cause-lbtc-depeg-or-protocol.md)
 
 </details>
 
@@ -19,10 +20,10 @@
 
 <summary>Low</summary>
 
-* \#38344 \[SC-Low] Old validated messages can not pass proof check when new validators are set
-* \#38137 \[SC-Low] \`RateLimits\` library incorrectly reset the consumed amount when the limit is updated
-* \#38231 \[SC-Low] Due to incorrect design in \`Consortium::setNextValidatorSet\` the validator set could not be set in certain valid scenarios
-* \#38286 \[SC-Low] BitcoinUtils.getDustLimitForOutput calculate wrongly the dust limit for a given Bitcoin script public key
+* [38344 - [SC - Low] Old validated messages can not pass proof check when new validators are set](./38344-sc-low-old-validated-messages-can-not-pass-proof-check-when-new-validators-are-set.md)
+* [38137 - [SC - Low] \`RateLimits\` library incorrectly reset the consumed amount when the limit is updated](./38137-sc-low-ratelimits-library-incorrectly-reset-the-consumed-amount-when-the-limit-is-updated.md)
+* [38231 - [SC - Low] Due to incorrect design in \`Consortium::setNextValidatorSet\` the validator set could not be set in certain valid scenarios](./38231-sc-low-due-to-incorrect-design-in-consortium-setnextvalidatorset-the-validator-set-could-not-b.md)
+* [38286 - [SC - Low] BitcoinUtils.getDustLimitForOutput calculate wrongly the dust limit for a given Bitcoin script public key](./38286-sc-low-bitcoinutils-getdustlimitforoutput-calculate-wrongly-the-dust-limit-for-a-given-bitcoin.md)
 
 </details>
 
@@ -30,44 +31,45 @@
 
 <summary>Insight</summary>
 
-* \#38644 \[SC-Insight] Q\&A
-* \#38102 \[SC-Insight] Due to incorrect design in \`BasculeV2::validateWithdrawal\` valid transactions will be reverted, which will make protocol unable to mint tokens
-* \#38012 \[SC-Insight] Unused Function in CLAdapter Contract
-* \#38116 \[SC-Insight] Partner vaults don't account for FireBridge fees, forcing LBTC burn to never work
-* \#38148 \[SC-Insight] Unnecessary Storage Pointer Declaration batchMintWithFee
-* \#38189 \[SC-Insight] Attacker can grief calls to \`lbtc.mintWithFee()\`
-* \#38225 \[SC-Insight] user funds will get stuck if \`removeDestination\` executes before notarization and withdraw.
-* \#38257 \[SC-Insight] Freezing of msg.value passed in Bridge.deposit() if adapter is address zero
-* \#38341 \[SC-Insight] Suboptimal gas usage and ambiguous behavior during fee estimation
-* \#38370 \[SC-Insight] Issue Between Comment and Code in Consortium
+* [38644 - [SC - Insight] Q\&A](./38644-sc-insight-q-and-a.md)
+* [38102 - [SC - Insight] Due to incorrect design in \`BasculeV2::validateWithdrawal\` valid transactions will be reverted, which will make protocol unable to mint tokens](./38102-sc-insight-due-to-incorrect-design-in-basculev2-validatewithdrawal-valid-transactions-will-be.md)
+* [38012 - [SC - Insight] Unused Function in CLAdapter Contract](./38012-sc-insight-unused-function-in-cladapter-contract.md)
+* [38116 - [SC - Insight] Partner vaults don't account for FireBridge fees, forcing LBTC burn to never work](./38116-sc-insight-partner-vaults-dont-account-for-firebridge-fees-forcing-lbtc-burn-to-never-work.md)
+* [38148 - [SC - Insight] Unnecessary Storage Pointer Declaration batchMintWithFee](./38148-sc-insight-unnecessary-storage-pointer-declaration-batchmintwithfee.md)
+* [38189 - [SC - Insight] Attacker can grief calls to \`lbtc.mintWithFee()\`](./38189-sc-insight-attacker-can-grief-calls-to-lbtc.mintwithfee.md)
+* [38225 - [SC - Insight] user funds will get stuck if \`removeDestination\` executes before notarization and withdraw.](./38225-sc-insight-user-funds-will-get-stuck-if-removedestination-executes-before-notarization-and-wit.md)
+* [38257 - [SC - Insight] Freezing of msg.value passed in Bridge.deposit() if adapter is address zero](./38257-sc-insight-freezing-of-msg.value-passed-in-bridge.deposit-if-adapter-is-address-zero.md)
+* [38341 - [SC - Insight] Suboptimal gas usage and ambiguous behavior during fee estimation](./38341-sc-insight-suboptimal-gas-usage-and-ambiguous-behavior-during-fee-estimation.md)
+* [38370 - [SC - Insight] Issue Between Comment and Code in Consortium](./38370-sc-insight-issue-between-comment-and-code-in-consortium.md)
 
 </details>
 
 ## Reports by Type
 
+[Smart Contract](<README.md#smart-contract>)
 <details>
 
 <summary>Smart Contract</summary>
 
-* \#38644 \[SC-Insight] Q\&A
-* \#38344 \[SC-Low] Old validated messages can not pass proof check when new validators are set
-* \#38137 \[SC-Low] \`RateLimits\` library incorrectly reset the consumed amount when the limit is updated
-* \#38102 \[SC-Insight] Due to incorrect design in \`BasculeV2::validateWithdrawal\` valid transactions will be reverted, which will make protocol unable to mint tokens
-* \#38634 \[SC-Medium] Insufficient validation on offchainTokenData in TokenPool.releaseOrMint allows CCIP message to be executed with mismatched payload potentially leading to loss of funds in cross-ch...
-* \#38012 \[SC-Insight] Unused Function in CLAdapter Contract
-* \#38066 \[SC-Medium] \`ProxyFactory\` is vulnerable to DoS/Address Hijacking
-* \#38116 \[SC-Insight] Partner vaults don't account for FireBridge fees, forcing LBTC burn to never work
-* \#38148 \[SC-Insight] Unnecessary Storage Pointer Declaration batchMintWithFee
-* \#38154 \[SC-Medium] The offchain data provided to the CLAdapter isn’t properly validated and can be from a different CCIP message, resulting in the freezing of funds
-* \#38189 \[SC-Insight] Attacker can grief calls to \`lbtc.mintWithFee()\`
-* \#38225 \[SC-Insight] user funds will get stuck if \`removeDestination\` executes before notarization and withdraw.
-* \#38257 \[SC-Insight] Freezing of msg.value passed in Bridge.deposit() if adapter is address zero
-* \#38231 \[SC-Low] Due to incorrect design in \`Consortium::setNextValidatorSet\` the validator set could not be set in certain valid scenarios
-* \#38286 \[SC-Low] BitcoinUtils.getDustLimitForOutput calculate wrongly the dust limit for a given Bitcoin script public key
-* \#38341 \[SC-Insight] Suboptimal gas usage and ambiguous behavior during fee estimation
-* \#38342 \[SC-Medium] Interchanging \`offchainTokenData\` between two valid messages
-* \#38363 \[SC-Medium] LBTC cross-chain transfer can be DOSed
-* \#38370 \[SC-Insight] Issue Between Comment and Code in Consortium
-* \#38335 \[SC-Medium] Attacker can exploit PartnerVault mint small amount to cause LBTC depeg or Protocol Insolvency
+* [38644 - [SC - Insight] Q\&A](./38644-sc-insight-q-and-a.md)
+* [38344 - [SC - Low] Old validated messages can not pass proof check when new validators are set](./38344-sc-low-old-validated-messages-can-not-pass-proof-check-when-new-validators-are-set.md)
+* [38137 - [SC - Low] \`RateLimits\` library incorrectly reset the consumed amount when the limit is updated](./38137-sc-low-ratelimits-library-incorrectly-reset-the-consumed-amount-when-the-limit-is-updated.md)
+* [38102 - [SC - Insight] Due to incorrect design in \`BasculeV2::validateWithdrawal\` valid transactions will be reverted, which will make protocol unable to mint tokens](./38102-sc-insight-due-to-incorrect-design-in-basculev2-validatewithdrawal-valid-transactions-will-be.md)
+* [38634 - [SC - Medium] Insufficient validation on offchainTokenData in TokenPool.releaseOrMint allows CCIP message to be executed with mismatched payload potentially leading to loss of funds in cross-ch...](./38634-sc-medium-insufficient-validation-on-offchaintokendata-in-tokenpool.releaseormint-allows-ccip.md)
+* [38012 - [SC - Insight] Unused Function in CLAdapter Contract](./38012-sc-insight-unused-function-in-cladapter-contract.md)
+* [38066 - [SC - Medium] \`ProxyFactory\` is vulnerable to DoS/Address Hijacking](./38066-sc-medium-proxyfactory-is-vulnerable-to-dos-address-hijacking.md)
+* [38116 - [SC - Insight] Partner vaults don't account for FireBridge fees, forcing LBTC burn to never work](./38116-sc-insight-partner-vaults-dont-account-for-firebridge-fees-forcing-lbtc-burn-to-never-work.md)
+* [38148 - [SC - Insight] Unnecessary Storage Pointer Declaration batchMintWithFee](./38148-sc-insight-unnecessary-storage-pointer-declaration-batchmintwithfee.md)
+* [38154 - [SC - Medium] The offchain data provided to the CLAdapter isn’t properly validated and can be from a different CCIP message, resulting in the freezing of funds](./38154-sc-medium-the-offchain-data-provided-to-the-cladapter-isnt-properly-validated-and-can-be-from.md)
+* [38189 - [SC - Insight] Attacker can grief calls to \`lbtc.mintWithFee()\`](./38189-sc-insight-attacker-can-grief-calls-to-lbtc.mintwithfee.md)
+* [38225 - [SC - Insight] user funds will get stuck if \`removeDestination\` executes before notarization and withdraw.](./38225-sc-insight-user-funds-will-get-stuck-if-removedestination-executes-before-notarization-and-wit.md)
+* [38257 - [SC - Insight] Freezing of msg.value passed in Bridge.deposit() if adapter is address zero](./38257-sc-insight-freezing-of-msg.value-passed-in-bridge.deposit-if-adapter-is-address-zero.md)
+* [38231 - [SC - Low] Due to incorrect design in \`Consortium::setNextValidatorSet\` the validator set could not be set in certain valid scenarios](./38231-sc-low-due-to-incorrect-design-in-consortium-setnextvalidatorset-the-validator-set-could-not-b.md)
+* [38286 - [SC - Low] BitcoinUtils.getDustLimitForOutput calculate wrongly the dust limit for a given Bitcoin script public key](./38286-sc-low-bitcoinutils-getdustlimitforoutput-calculate-wrongly-the-dust-limit-for-a-given-bitcoin.md)
+* [38341 - [SC - Insight] Suboptimal gas usage and ambiguous behavior during fee estimation](./38341-sc-insight-suboptimal-gas-usage-and-ambiguous-behavior-during-fee-estimation.md)
+* [38342 - [SC - Medium] Interchanging \`offchainTokenData\` between two valid messages](./38342-sc-medium-interchanging-offchaintokendata-between-two-valid-messages.md)
+* [38363 - [SC - Medium] LBTC cross-chain transfer can be DOSed](./38363-sc-medium-lbtc-cross-chain-transfer-can-be-dosed.md)
+* [38370 - [SC - Insight] Issue Between Comment and Code in Consortium](./38370-sc-insight-issue-between-comment-and-code-in-consortium.md)
+* [38335 - [SC - Medium] Attacker can exploit PartnerVault mint small amount to cause LBTC depeg or Protocol Insolvency](./38335-sc-medium-attacker-can-exploit-partnervault-mint-small-amount-to-cause-lbtc-depeg-or-protocol.md)
 
 </details>

--- a/shardeum-ancillaries-ii/README.md
+++ b/shardeum-ancillaries-ii/README.md
@@ -2,12 +2,13 @@
 
 ## Reports by Severity
 
+[Critical](<README.md#critical>) | [High](<README.md#high>) | [Medium](<README.md#medium>) | [Insight](<README.md#insight>)
 <details>
 
 <summary>Critical</summary>
 
-* \#35709 \[W\&A-Critical] Potential DoS of archiver-server during network restoration via get\_account\_data\_archiver call
-* \#36025 \[W\&A-Critical] A malicious validator can overwrite the account data of any archive server connected to it.
+* [35709 - [W\&A - Critical] Potential DoS of archiver-server during network restoration via get\_account\_data\_archiver call](./35709-w-and-a-critical-potential-dos-of-archiver-server-during-network-restoration-via-get_account_d.md)
+* [36025 - [W\&A - Critical] A malicious validator can overwrite the account data of any archive server connected to it.](./36025-w-and-a-critical-a-malicious-validator-can-overwrite-the-account-data-of-any-archive-server-co.md)
 
 </details>
 
@@ -15,10 +16,10 @@
 
 <summary>High</summary>
 
-* \#35903 \[W\&A-High] SQL Injection Allows a Malicious Archiver to Overwrite Receipt/originalTxData Database on Any Active Archiver in the Network
-* \#35447 \[W\&A-High] Zero Click Full Account Takeover
-* \#35452 \[W\&A-High] Admin Panel Accessed
-* \#35979 \[W\&A-High] Malicious Archiver/Malicious Validator can overwrite data on any active archiver and more
+* [35903 - [W\&A - High] SQL Injection Allows a Malicious Archiver to Overwrite Receipt/originalTxData Database on Any Active Archiver in the Network](./35903-w-and-a-high-sql-injection-allows-a-malicious-archiver-to-overwrite-receipt-originaltxdata-dat.md)
+* [35447 - [W\&A - High] Zero Click Full Account Takeover](./35447-w-and-a-high-zero-click-full-account-takeover.md)
+* [35452 - [W\&A - High] Admin Panel Accessed](./35452-w-and-a-high-admin-panel-accessed.md)
+* [35979 - [W\&A - High] Malicious Archiver/Malicious Validator can overwrite data on any active archiver and more](./35979-w-and-a-high-malicious-archiver-malicious-validator-can-overwrite-data-on-any-active-archiver.md)
 
 </details>
 
@@ -26,7 +27,7 @@
 
 <summary>Medium</summary>
 
-* \#35824 \[W\&A-Medium] \`/set-config\` replay attack is possible in production mode after archiver restart
+* [35824 - [W\&A - Medium] \`/set-config\` replay attack is possible in production mode after archiver restart](./35824-w-and-a-medium-set-config-replay-attack-is-possible-in-production-mode-after-archiver-restart.md)
 
 </details>
 
@@ -34,39 +35,40 @@
 
 <summary>Insight</summary>
 
-* \#35157 \[W\&A-Insight] Unauthorized Access to Shardeum Config Store using default credentials
-* \#35534 \[W\&A-Insight] json rpc server remote crash
-* \#35446 \[W\&A-Insight] IDOR Able to change other user information
-* \#35972 \[W\&A-Insight] Operator-GUI Weak JWT Token Generation Led To Generate same JWT Tokens Even if The User Has it's Unique "nodeId"
-* \#36005 \[W\&A-Insight] Reflected URL Manipulation and Phishing Risk
-* \#35996 \[W\&A-Insight] Malicious Explorer can cause Denial of Service in JSON RPC server and even crash it
-* \#35537 \[W\&A-Insight] json rpc server websocket remote crash
-* \#35351 \[W\&A-Insight] Password Length Bypass in Shardeum Authentication System
-* \#35598 \[W\&A-Insight] Access to debug endpoints without any protection
+* [35157 - [W\&A - Insight] Unauthorized Access to Shardeum Config Store using default credentials](./35157-w-and-a-insight-unauthorized-access-to-shardeum-config-store-using-default-credentials.md)
+* [35534 - [W\&A - Insight] json rpc server remote crash](./35534-w-and-a-insight-json-rpc-server-remote-crash.md)
+* [35446 - [W\&A - Insight] IDOR Able to change other user information](./35446-w-and-a-insight-idor-able-to-change-other-user-information.md)
+* [35972 - [W\&A - Insight] Operator-GUI Weak JWT Token Generation Led To Generate same JWT Tokens Even if The User Has it's Unique "nodeId"](./35972-w-and-a-insight-operator-gui-weak-jwt-token-generation-led-to-generate-same-jwt-tokens-even-if.md)
+* [36005 - [W\&A - Insight] Reflected URL Manipulation and Phishing Risk](./36005-w-and-a-insight-reflected-url-manipulation-and-phishing-risk.md)
+* [35996 - [W\&A - Insight] Malicious Explorer can cause Denial of Service in JSON RPC server and even crash it](./35996-w-and-a-insight-malicious-explorer-can-cause-denial-of-service-in-json-rpc-server-and-even-cra.md)
+* [35537 - [W\&A - Insight] json rpc server websocket remote crash](./35537-w-and-a-insight-json-rpc-server-websocket-remote-crash.md)
+* [35351 - [W\&A - Insight] Password Length Bypass in Shardeum Authentication System](./35351-w-and-a-insight-password-length-bypass-in-shardeum-authentication-system.md)
+* [35598 - [W\&A - Insight] Access to debug endpoints without any protection](./35598-w-and-a-insight-access-to-debug-endpoints-without-any-protection.md)
 
 </details>
 
 ## Reports by Type
 
+[Websites &#x26; Applications](<README.md#websites-applications>)
 <details>
 
 <summary>Websites &#x26; Applications</summary>
 
-* \#35709 \[W\&A-Critical] Potential DoS of archiver-server during network restoration via get\_account\_data\_archiver call
-* \#35157 \[W\&A-Insight] Unauthorized Access to Shardeum Config Store using default credentials
-* \#35534 \[W\&A-Insight] json rpc server remote crash
-* \#35824 \[W\&A-Medium] \`/set-config\` replay attack is possible in production mode after archiver restart
-* \#35903 \[W\&A-High] SQL Injection Allows a Malicious Archiver to Overwrite Receipt/originalTxData Database on Any Active Archiver in the Network
-* \#35446 \[W\&A-Insight] IDOR Able to change other user information
-* \#35447 \[W\&A-High] Zero Click Full Account Takeover
-* \#35972 \[W\&A-Insight] Operator-GUI Weak JWT Token Generation Led To Generate same JWT Tokens Even if The User Has it's Unique "nodeId"
-* \#35452 \[W\&A-High] Admin Panel Accessed
-* \#36005 \[W\&A-Insight] Reflected URL Manipulation and Phishing Risk
-* \#36025 \[W\&A-Critical] A malicious validator can overwrite the account data of any archive server connected to it.
-* \#35979 \[W\&A-High] Malicious Archiver/Malicious Validator can overwrite data on any active archiver and more
-* \#35996 \[W\&A-Insight] Malicious Explorer can cause Denial of Service in JSON RPC server and even crash it
-* \#35537 \[W\&A-Insight] json rpc server websocket remote crash
-* \#35351 \[W\&A-Insight] Password Length Bypass in Shardeum Authentication System
-* \#35598 \[W\&A-Insight] Access to debug endpoints without any protection
+* [35709 - [W\&A - Critical] Potential DoS of archiver-server during network restoration via get\_account\_data\_archiver call](./35709-w-and-a-critical-potential-dos-of-archiver-server-during-network-restoration-via-get_account_d.md)
+* [35157 - [W\&A - Insight] Unauthorized Access to Shardeum Config Store using default credentials](./35157-w-and-a-insight-unauthorized-access-to-shardeum-config-store-using-default-credentials.md)
+* [35534 - [W\&A - Insight] json rpc server remote crash](./35534-w-and-a-insight-json-rpc-server-remote-crash.md)
+* [35824 - [W\&A - Medium] \`/set-config\` replay attack is possible in production mode after archiver restart](./35824-w-and-a-medium-set-config-replay-attack-is-possible-in-production-mode-after-archiver-restart.md)
+* [35903 - [W\&A - High] SQL Injection Allows a Malicious Archiver to Overwrite Receipt/originalTxData Database on Any Active Archiver in the Network](./35903-w-and-a-high-sql-injection-allows-a-malicious-archiver-to-overwrite-receipt-originaltxdata-dat.md)
+* [35446 - [W\&A - Insight] IDOR Able to change other user information](./35446-w-and-a-insight-idor-able-to-change-other-user-information.md)
+* [35447 - [W\&A - High] Zero Click Full Account Takeover](./35447-w-and-a-high-zero-click-full-account-takeover.md)
+* [35972 - [W\&A - Insight] Operator-GUI Weak JWT Token Generation Led To Generate same JWT Tokens Even if The User Has it's Unique "nodeId"](./35972-w-and-a-insight-operator-gui-weak-jwt-token-generation-led-to-generate-same-jwt-tokens-even-if.md)
+* [35452 - [W\&A - High] Admin Panel Accessed](./35452-w-and-a-high-admin-panel-accessed.md)
+* [36005 - [W\&A - Insight] Reflected URL Manipulation and Phishing Risk](./36005-w-and-a-insight-reflected-url-manipulation-and-phishing-risk.md)
+* [36025 - [W\&A - Critical] A malicious validator can overwrite the account data of any archive server connected to it.](./36025-w-and-a-critical-a-malicious-validator-can-overwrite-the-account-data-of-any-archive-server-co.md)
+* [35979 - [W\&A - High] Malicious Archiver/Malicious Validator can overwrite data on any active archiver and more](./35979-w-and-a-high-malicious-archiver-malicious-validator-can-overwrite-data-on-any-active-archiver.md)
+* [35996 - [W\&A - Insight] Malicious Explorer can cause Denial of Service in JSON RPC server and even crash it](./35996-w-and-a-insight-malicious-explorer-can-cause-denial-of-service-in-json-rpc-server-and-even-cra.md)
+* [35537 - [W\&A - Insight] json rpc server websocket remote crash](./35537-w-and-a-insight-json-rpc-server-websocket-remote-crash.md)
+* [35351 - [W\&A - Insight] Password Length Bypass in Shardeum Authentication System](./35351-w-and-a-insight-password-length-bypass-in-shardeum-authentication-system.md)
+* [35598 - [W\&A - Insight] Access to debug endpoints without any protection](./35598-w-and-a-insight-access-to-debug-endpoints-without-any-protection.md)
 
 </details>

--- a/shardeum-ancillaries-iii/README.md
+++ b/shardeum-ancillaries-iii/README.md
@@ -2,17 +2,18 @@
 
 ## Reports by Severity
 
+[Critical](<README.md#critical>) | [Medium](<README.md#medium>) | [Low](<README.md#low>) | [Insight](<README.md#insight>)
 <details>
 
 <summary>Critical</summary>
 
-* \#39626 \[W\&A-Critical] Malicious Validator Can Overwrite Any Cycle Data
-* \#39872 \[W\&A-Critical] Bypass Receipt Signing Validation
-* \#39893 \[W\&A-Critical] Malicious Validator Can Modify \`txId\` in Global Transactions
-* \#39434 \[W\&A-Critical] Improper serialization can create an out-of-memory (OOM) issue on the archive server.
-* \#39980 \[W\&A-Critical] Malicious validator can inject its own cycle record into connected archiver
-* \#40004 \[W\&A-Critical] Multiple vulnerabilities in signature verification during receipt processing on the archiver server
-* \#39829 \[W\&A-Critical] DOS archiver via data subscription channel due to broken safeStringfy
+* [39626 - [W\&A - Critical] Malicious Validator Can Overwrite Any Cycle Data](./39626-w-and-a-critical-malicious-validator-can-overwrite-any-cycle-data.md)
+* [39872 - [W\&A - Critical] Bypass Receipt Signing Validation](./39872-w-and-a-critical-bypass-receipt-signing-validation.md)
+* [39893 - [W\&A - Critical] Malicious Validator Can Modify \`txId\` in Global Transactions](./39893-w-and-a-critical-malicious-validator-can-modify-txid-in-global-transactions.md)
+* [39434 - [W\&A - Critical] Improper serialization can create an out-of-memory (OOM) issue on the archive server.](./39434-w-and-a-critical-improper-serialization-can-create-an-out-of-memory-oom-issue-on-the-archive-s.md)
+* [39980 - [W\&A - Critical] Malicious validator can inject its own cycle record into connected archiver](./39980-w-and-a-critical-malicious-validator-can-inject-its-own-cycle-record-into-connected-archiver.md)
+* [40004 - [W\&A - Critical] Multiple vulnerabilities in signature verification during receipt processing on the archiver server](./40004-w-and-a-critical-multiple-vulnerabilities-in-signature-verification-during-receipt-processing.md)
+* [39829 - [W\&A - Critical] DOS archiver via data subscription channel due to broken safeStringfy](./39829-w-and-a-critical-dos-archiver-via-data-subscription-channel-due-to-broken-safestringfy.md)
 
 </details>
 
@@ -20,10 +21,10 @@
 
 <summary>Medium</summary>
 
-* \#39820 \[W\&A-Medium] Blocking all users from interacting with particular contracts/protocols via JSON-RPC server
-* \#39284 \[W\&A-Medium] Arbitrarily set any archiver config and remotely turning it off
-* \#39910 \[W\&A-Medium] Numerous replay attacks (with arbitrary data) to protected endpoints are possible
-* \#39942 \[W\&A-Medium] Archiver is still vulnerable to replay attack to \`/set-config\`
+* [39820 - [W\&A - Medium] Blocking all users from interacting with particular contracts/protocols via JSON-RPC server](./39820-w-and-a-medium-blocking-all-users-from-interacting-with-particular-contracts-protocols-via-jso.md)
+* [39284 - [W\&A - Medium] Arbitrarily set any archiver config and remotely turning it off](./39284-w-and-a-medium-arbitrarily-set-any-archiver-config-and-remotely-turning-it-off.md)
+* [39910 - [W\&A - Medium] Numerous replay attacks (with arbitrary data) to protected endpoints are possible](./39910-w-and-a-medium-numerous-replay-attacks-with-arbitrary-data-to-protected-endpoints-are-possible.md)
+* [39942 - [W\&A - Medium] Archiver is still vulnerable to replay attack to \`/set-config\`](./39942-w-and-a-medium-archiver-is-still-vulnerable-to-replay-attack-to-set-config.md)
 
 </details>
 
@@ -31,9 +32,9 @@
 
 <summary>Low</summary>
 
-* \#39993 \[W\&A-Low] node-fetch without response limit
-* \#39623 \[W\&A-Low] Blocking the victim's account address from sending transactions via JSON-RPC
-* \#39814 \[W\&A-Low] Prevent new validators from joining the network by a DOS of the archiver
+* [39993 - [W\&A - Low] node-fetch without response limit](./39993-w-and-a-low-node-fetch-without-response-limit.md)
+* [39623 - [W\&A - Low] Blocking the victim's account address from sending transactions via JSON-RPC](./39623-w-and-a-low-blocking-the-victims-account-address-from-sending-transactions-via-json-rpc.md)
+* [39814 - [W\&A - Low] Prevent new validators from joining the network by a DOS of the archiver](./39814-w-and-a-low-prevent-new-validators-from-joining-the-network-by-a-dos-of-the-archiver.md)
 
 </details>
 
@@ -41,34 +42,35 @@
 
 <summary>Insight</summary>
 
-* \#39109 \[W\&A-Insight] syncStateDataGlobals will not work, effectively DoS'ing nodes
-* \#39944 \[W\&A-Insight] Incorrect Default Configuration Leading to Dead Code
-* \#39360 \[W\&A-Insight] getRandomActiveNodes may return inconsistent results
+* [39109 - [W\&A - Insight] syncStateDataGlobals will not work, effectively DoS'ing nodes](./39109-w-and-a-insight-syncstatedataglobals-will-not-work-effectively-dosing-nodes.md)
+* [39944 - [W\&A - Insight] Incorrect Default Configuration Leading to Dead Code](./39944-w-and-a-insight-incorrect-default-configuration-leading-to-dead-code.md)
+* [39360 - [W\&A - Insight] getRandomActiveNodes may return inconsistent results](./39360-w-and-a-insight-getrandomactivenodes-may-return-inconsistent-results.md)
 
 </details>
 
 ## Reports by Type
 
+[Websites &#x26; Applications](<README.md#websites-applications>)
 <details>
 
 <summary>Websites &#x26; Applications</summary>
 
-* \#39993 \[W\&A-Low] node-fetch without response limit
-* \#39820 \[W\&A-Medium] Blocking all users from interacting with particular contracts/protocols via JSON-RPC server
-* \#39626 \[W\&A-Critical] Malicious Validator Can Overwrite Any Cycle Data
-* \#39623 \[W\&A-Low] Blocking the victim's account address from sending transactions via JSON-RPC
-* \#39109 \[W\&A-Insight] syncStateDataGlobals will not work, effectively DoS'ing nodes
-* \#39284 \[W\&A-Medium] Arbitrarily set any archiver config and remotely turning it off
-* \#39814 \[W\&A-Low] Prevent new validators from joining the network by a DOS of the archiver
-* \#39872 \[W\&A-Critical] Bypass Receipt Signing Validation
-* \#39893 \[W\&A-Critical] Malicious Validator Can Modify \`txId\` in Global Transactions
-* \#39910 \[W\&A-Medium] Numerous replay attacks (with arbitrary data) to protected endpoints are possible
-* \#39944 \[W\&A-Insight] Incorrect Default Configuration Leading to Dead Code
-* \#39434 \[W\&A-Critical] Improper serialization can create an out-of-memory (OOM) issue on the archive server.
-* \#39980 \[W\&A-Critical] Malicious validator can inject its own cycle record into connected archiver
-* \#39942 \[W\&A-Medium] Archiver is still vulnerable to replay attack to \`/set-config\`
-* \#40004 \[W\&A-Critical] Multiple vulnerabilities in signature verification during receipt processing on the archiver server
-* \#39829 \[W\&A-Critical] DOS archiver via data subscription channel due to broken safeStringfy
-* \#39360 \[W\&A-Insight] getRandomActiveNodes may return inconsistent results
+* [39993 - [W\&A - Low] node-fetch without response limit](./39993-w-and-a-low-node-fetch-without-response-limit.md)
+* [39820 - [W\&A - Medium] Blocking all users from interacting with particular contracts/protocols via JSON-RPC server](./39820-w-and-a-medium-blocking-all-users-from-interacting-with-particular-contracts-protocols-via-jso.md)
+* [39626 - [W\&A - Critical] Malicious Validator Can Overwrite Any Cycle Data](./39626-w-and-a-critical-malicious-validator-can-overwrite-any-cycle-data.md)
+* [39623 - [W\&A - Low] Blocking the victim's account address from sending transactions via JSON-RPC](./39623-w-and-a-low-blocking-the-victims-account-address-from-sending-transactions-via-json-rpc.md)
+* [39109 - [W\&A - Insight] syncStateDataGlobals will not work, effectively DoS'ing nodes](./39109-w-and-a-insight-syncstatedataglobals-will-not-work-effectively-dosing-nodes.md)
+* [39284 - [W\&A - Medium] Arbitrarily set any archiver config and remotely turning it off](./39284-w-and-a-medium-arbitrarily-set-any-archiver-config-and-remotely-turning-it-off.md)
+* [39814 - [W\&A - Low] Prevent new validators from joining the network by a DOS of the archiver](./39814-w-and-a-low-prevent-new-validators-from-joining-the-network-by-a-dos-of-the-archiver.md)
+* [39872 - [W\&A - Critical] Bypass Receipt Signing Validation](./39872-w-and-a-critical-bypass-receipt-signing-validation.md)
+* [39893 - [W\&A - Critical] Malicious Validator Can Modify \`txId\` in Global Transactions](./39893-w-and-a-critical-malicious-validator-can-modify-txid-in-global-transactions.md)
+* [39910 - [W\&A - Medium] Numerous replay attacks (with arbitrary data) to protected endpoints are possible](./39910-w-and-a-medium-numerous-replay-attacks-with-arbitrary-data-to-protected-endpoints-are-possible.md)
+* [39944 - [W\&A - Insight] Incorrect Default Configuration Leading to Dead Code](./39944-w-and-a-insight-incorrect-default-configuration-leading-to-dead-code.md)
+* [39434 - [W\&A - Critical] Improper serialization can create an out-of-memory (OOM) issue on the archive server.](./39434-w-and-a-critical-improper-serialization-can-create-an-out-of-memory-oom-issue-on-the-archive-s.md)
+* [39980 - [W\&A - Critical] Malicious validator can inject its own cycle record into connected archiver](./39980-w-and-a-critical-malicious-validator-can-inject-its-own-cycle-record-into-connected-archiver.md)
+* [39942 - [W\&A - Medium] Archiver is still vulnerable to replay attack to \`/set-config\`](./39942-w-and-a-medium-archiver-is-still-vulnerable-to-replay-attack-to-set-config.md)
+* [40004 - [W\&A - Critical] Multiple vulnerabilities in signature verification during receipt processing on the archiver server](./40004-w-and-a-critical-multiple-vulnerabilities-in-signature-verification-during-receipt-processing.md)
+* [39829 - [W\&A - Critical] DOS archiver via data subscription channel due to broken safeStringfy](./39829-w-and-a-critical-dos-archiver-via-data-subscription-channel-due-to-broken-safestringfy.md)
+* [39360 - [W\&A - Insight] getRandomActiveNodes may return inconsistent results](./39360-w-and-a-insight-getrandomactivenodes-may-return-inconsistent-results.md)
 
 </details>

--- a/shardeum-core-ii/README.md
+++ b/shardeum-core-ii/README.md
@@ -2,18 +2,19 @@
 
 ## Reports by Severity
 
+[Critical](<README.md#critical>) | [Insight](<README.md#insight>)
 <details>
 
 <summary>Critical</summary>
 
-* \#35526 \[BC-Critical] An attacker can change the account balance after the transaction has been processed.
-* \#35839 \[BC-Critical] Slash avoidance: Ineffective controls on unstaking allow unstaking before taking an action that should be slashed
-* \#35707 \[BC-Critical] Reusing old transaction receipt to rollback account balance
-* \#35531 \[BC-Critical] Absence of signature deduplication for receipt in the binary\_repair\_oos\_accounts P2P handler
-* \#35695 \[BC-Critical] validateTxnFields check for internal transactions can be bypassed
-* \#35601 \[BC-Critical] Consensus algorithm doesn't deduplicate votes, allowing a malicious validator to completely falsify transactions
-* \#35694 \[BC-Critical] Consensus can be bypassed by single validator node from transaction execution group
-* \#35696 \[BC-Critical] Specifically crafted penalty TX may cause total network shutdown.
+* [35526 - [BC - Critical] An attacker can change the account balance after the transaction has been processed.](./35526-bc-critical-an-attacker-can-change-the-account-balance-after-the-transaction-has-been-processe.md)
+* [35839 - [BC - Critical] Slash avoidance: Ineffective controls on unstaking allow unstaking before taking an action that should be slashed](./35839-bc-critical-slash-avoidance-ineffective-controls-on-unstaking-allow-unstaking-before-taking-an.md)
+* [35707 - [BC - Critical] Reusing old transaction receipt to rollback account balance](./35707-bc-critical-reusing-old-transaction-receipt-to-rollback-account-balance.md)
+* [35531 - [BC - Critical] Absence of signature deduplication for receipt in the binary\_repair\_oos\_accounts P2P handler](./35531-bc-critical-absence-of-signature-deduplication-for-receipt-in-the-binary_repair_oos_accounts-p.md)
+* [35695 - [BC - Critical] validateTxnFields check for internal transactions can be bypassed](./35695-bc-critical-validatetxnfields-check-for-internal-transactions-can-be-bypassed.md)
+* [35601 - [BC - Critical] Consensus algorithm doesn't deduplicate votes, allowing a malicious validator to completely falsify transactions](./35601-bc-critical-consensus-algorithm-doesnt-deduplicate-votes-allowing-a-malicious-validator-to-com.md)
+* [35694 - [BC - Critical] Consensus can be bypassed by single validator node from transaction execution group](./35694-bc-critical-consensus-can-be-bypassed-by-single-validator-node-from-transaction-execution-grou.md)
+* [35696 - [BC - Critical] Specifically crafted penalty TX may cause total network shutdown.](./35696-bc-critical-specifically-crafted-penalty-tx-may-cause-total-network-shutdown..md)
 
 </details>
 
@@ -21,36 +22,37 @@
 
 <summary>Insight</summary>
 
-* \#35710 \[BC-Insight] addressToPartition input is unsanitized, allowing to take whole network down
-* \#35697 \[BC-Insight] \[Informational] Code logic contains potential risk of full network shutdown
-* \#35641 \[BC-Insight] node p2p remote denial of service
-* \#35415 \[BC-Insight] \[Informational] debugMiddleware query parameters can be partially modified by request submitter or via MITM
-* \#35965 \[BC-Insight] Unverified Data in Safety Sync
-* \#36024 \[BC-Insight] Use of Vulnerable function results in prediction of archivers
-* \#36029 \[BC-Insight] Node.js crash on counterMap overflow
+* [35710 - [BC - Insight] addressToPartition input is unsanitized, allowing to take whole network down](./35710-bc-insight-addresstopartition-input-is-unsanitized-allowing-to-take-whole-network-down.md)
+* [35697 - [BC - Insight] [Informational] Code logic contains potential risk of full network shutdown](./35697-bc-insight-informational-code-logic-contains-potential-risk-of-full-network-shutdown.md)
+* [35641 - [BC - Insight] node p2p remote denial of service](./35641-bc-insight-node-p2p-remote-denial-of-service.md)
+* [35415 - [BC - Insight] [Informational] debugMiddleware query parameters can be partially modified by request submitter or via MITM](./35415-bc-insight-informational-debugmiddleware-query-parameters-can-be-partially-modified-by-request.md)
+* [35965 - [BC - Insight] Unverified Data in Safety Sync](./35965-bc-insight-unverified-data-in-safety-sync.md)
+* [36024 - [BC - Insight] Use of Vulnerable function results in prediction of archivers](./36024-bc-insight-use-of-vulnerable-function-results-in-prediction-of-archivers.md)
+* [36029 - [BC - Insight] Node.js crash on counterMap overflow](./36029-bc-insight-node.js-crash-on-countermap-overflow.md)
 
 </details>
 
 ## Reports by Type
 
+[Blockchain/DLT](<README.md#blockchain-dlt>)
 <details>
 
 <summary>Blockchain/DLT</summary>
 
-* \#35710 \[BC-Insight] addressToPartition input is unsanitized, allowing to take whole network down
-* \#35697 \[BC-Insight] \[Informational] Code logic contains potential risk of full network shutdown
-* \#35641 \[BC-Insight] node p2p remote denial of service
-* \#35526 \[BC-Critical] An attacker can change the account balance after the transaction has been processed.
-* \#35415 \[BC-Insight] \[Informational] debugMiddleware query parameters can be partially modified by request submitter or via MITM
-* \#35839 \[BC-Critical] Slash avoidance: Ineffective controls on unstaking allow unstaking before taking an action that should be slashed
-* \#35707 \[BC-Critical] Reusing old transaction receipt to rollback account balance
-* \#35965 \[BC-Insight] Unverified Data in Safety Sync
-* \#36024 \[BC-Insight] Use of Vulnerable function results in prediction of archivers
-* \#35531 \[BC-Critical] Absence of signature deduplication for receipt in the binary\_repair\_oos\_accounts P2P handler
-* \#35695 \[BC-Critical] validateTxnFields check for internal transactions can be bypassed
-* \#35601 \[BC-Critical] Consensus algorithm doesn't deduplicate votes, allowing a malicious validator to completely falsify transactions
-* \#35694 \[BC-Critical] Consensus can be bypassed by single validator node from transaction execution group
-* \#36029 \[BC-Insight] Node.js crash on counterMap overflow
-* \#35696 \[BC-Critical] Specifically crafted penalty TX may cause total network shutdown.
+* [35710 - [BC - Insight] addressToPartition input is unsanitized, allowing to take whole network down](./35710-bc-insight-addresstopartition-input-is-unsanitized-allowing-to-take-whole-network-down.md)
+* [35697 - [BC - Insight] [Informational] Code logic contains potential risk of full network shutdown](./35697-bc-insight-informational-code-logic-contains-potential-risk-of-full-network-shutdown.md)
+* [35641 - [BC - Insight] node p2p remote denial of service](./35641-bc-insight-node-p2p-remote-denial-of-service.md)
+* [35526 - [BC - Critical] An attacker can change the account balance after the transaction has been processed.](./35526-bc-critical-an-attacker-can-change-the-account-balance-after-the-transaction-has-been-processe.md)
+* [35415 - [BC - Insight] [Informational] debugMiddleware query parameters can be partially modified by request submitter or via MITM](./35415-bc-insight-informational-debugmiddleware-query-parameters-can-be-partially-modified-by-request.md)
+* [35839 - [BC - Critical] Slash avoidance: Ineffective controls on unstaking allow unstaking before taking an action that should be slashed](./35839-bc-critical-slash-avoidance-ineffective-controls-on-unstaking-allow-unstaking-before-taking-an.md)
+* [35707 - [BC - Critical] Reusing old transaction receipt to rollback account balance](./35707-bc-critical-reusing-old-transaction-receipt-to-rollback-account-balance.md)
+* [35965 - [BC - Insight] Unverified Data in Safety Sync](./35965-bc-insight-unverified-data-in-safety-sync.md)
+* [36024 - [BC - Insight] Use of Vulnerable function results in prediction of archivers](./36024-bc-insight-use-of-vulnerable-function-results-in-prediction-of-archivers.md)
+* [35531 - [BC - Critical] Absence of signature deduplication for receipt in the binary\_repair\_oos\_accounts P2P handler](./35531-bc-critical-absence-of-signature-deduplication-for-receipt-in-the-binary_repair_oos_accounts-p.md)
+* [35695 - [BC - Critical] validateTxnFields check for internal transactions can be bypassed](./35695-bc-critical-validatetxnfields-check-for-internal-transactions-can-be-bypassed.md)
+* [35601 - [BC - Critical] Consensus algorithm doesn't deduplicate votes, allowing a malicious validator to completely falsify transactions](./35601-bc-critical-consensus-algorithm-doesnt-deduplicate-votes-allowing-a-malicious-validator-to-com.md)
+* [35694 - [BC - Critical] Consensus can be bypassed by single validator node from transaction execution group](./35694-bc-critical-consensus-can-be-bypassed-by-single-validator-node-from-transaction-execution-grou.md)
+* [36029 - [BC - Insight] Node.js crash on counterMap overflow](./36029-bc-insight-node.js-crash-on-countermap-overflow.md)
+* [35696 - [BC - Critical] Specifically crafted penalty TX may cause total network shutdown.](./35696-bc-critical-specifically-crafted-penalty-tx-may-cause-total-network-shutdown..md)
 
 </details>

--- a/stacks-i-attackathon/README.md
+++ b/stacks-i-attackathon/README.md
@@ -2,12 +2,13 @@
 
 ## Reports by Severity
 
+[Critical](<README.md#critical>) | [High](<README.md#high>) | [Medium](<README.md#medium>) | [Low](<README.md#low>) | [Insight](<README.md#insight>)
 <details>
 
 <summary>Critical</summary>
 
-* \#37861 \[BC-Critical] SBTC Signer WSTS implementation allows nonce replays such that a malicious signer can steal all funds
-* \#38458 \[BC-Critical] The coordinator can submit empty BTC transactions to drain BTC tokens in the multi-sign wallet
+* [37861 - [BC - Critical] SBTC Signer WSTS implementation allows nonce replays such that a malicious signer can steal all funds](./37861-bc-critical-sbtc-signer-wsts-implementation-allows-nonce-replays-such-that-a-malicious-signer.md)
+* [38458 - [BC - Critical] The coordinator can submit empty BTC transactions to drain BTC tokens in the multi-sign wallet](./38458-bc-critical-the-coordinator-can-submit-empty-btc-transactions-to-drain-btc-tokens-in-the-multi.md)
 
 </details>
 
@@ -15,18 +16,18 @@
 
 <summary>High</summary>
 
-* \#37718 \[BC-High] Key rotations bricks the system due to incorrect \`aggregate\_key\` being used to spend the \`peg UTXO\` when signing a sweep transaction
-* \#37811 \[BC-High] Missing length check when parsing \`SignatureShareRequest\` in the signers allows the coordinator to halt other signers, shutting down the network
-* \#37814 \[BC-High] Signers can crash other signers by sending an invalid \`DkgPrivateShares\` due to missing check before passing the payload to \`SignerStateMachine::process\`
-* \#38582 \[BC-High] The \`BitcoinCoreClient::get\_tx\_info\` does not support coinbase transactions, which may cause sBTC to be attacked by btc miners or sBTC donations to be lost
-* \#38392 \[BC-High] Signer can steal STX tokens in multi-sign wallet by setting a high stacks tx fee
-* \#38740 \[BC-High] The missing check in Deposits::DepositScriptInputs::parse() permits losing funds by sending them to an invalid principal
-* \#38053 \[BC-High] A single signer can continuously prevent signatures from being finalized, halting network operations
-* \#38477 \[BC-High] A single signer can abort every attempted signing round by providing an invalid packet once the coordinator requests signature shares
-* \#38111 \[BC-High] Attackers can send a very large event in a Stacks block so that the Signer can never get the Stacks event
-* \#38398 \[BC-High] Malicious Signers can initiate repeated contract calls to cause the multi-sign wallet to lose tx fee
-* \#37479 \[BC-High] A single signer can lock users' funds by not notifying other signers of the executed \`sweep\` transaction
-* \#38516 \[BC-High] Signer can censor transactions and halt the network by providing an invalid nonce or too many nonces
+* [37718 - [BC - High] Key rotations bricks the system due to incorrect \`aggregate\_key\` being used to spend the \`peg UTXO\` when signing a sweep transaction](./37718-bc-high-key-rotations-bricks-the-system-due-to-incorrect-aggregate_key-being-used-to-spend-the.md)
+* [37811 - [BC - High] Missing length check when parsing \`SignatureShareRequest\` in the signers allows the coordinator to halt other signers, shutting down the network](./37811-bc-high-missing-length-check-when-parsing-signaturesharerequest-in-the-signers-allows-the-coor.md)
+* [37814 - [BC - High] Signers can crash other signers by sending an invalid \`DkgPrivateShares\` due to missing check before passing the payload to \`SignerStateMachine::process\`](./37814-bc-high-signers-can-crash-other-signers-by-sending-an-invalid-dkgprivateshares-due-to-missing.md)
+* [38582 - [BC - High] The \`BitcoinCoreClient::get\_tx\_info\` does not support coinbase transactions, which may cause sBTC to be attacked by btc miners or sBTC donations to be lost](./38582-bc-high-the-bitcoincoreclient-get_tx_info-does-not-support-coinbase-transactions-which-may-cau.md)
+* [38392 - [BC - High] Signer can steal STX tokens in multi-sign wallet by setting a high stacks tx fee](./38392-bc-high-signer-can-steal-stx-tokens-in-multi-sign-wallet-by-setting-a-high-stacks-tx-fee.md)
+* [38740 - [BC - High] The missing check in Deposits::DepositScriptInputs::parse() permits losing funds by sending them to an invalid principal](./38740-bc-high-the-missing-check-in-deposits-depositscriptinputs-parse-permits-losing-funds-by-sendin.md)
+* [38053 - [BC - High] A single signer can continuously prevent signatures from being finalized, halting network operations](./38053-bc-high-a-single-signer-can-continuously-prevent-signatures-from-being-finalized-halting-netwo.md)
+* [38477 - [BC - High] A single signer can abort every attempted signing round by providing an invalid packet once the coordinator requests signature shares](./38477-bc-high-a-single-signer-can-abort-every-attempted-signing-round-by-providing-an-invalid-packet.md)
+* [38111 - [BC - High] Attackers can send a very large event in a Stacks block so that the Signer can never get the Stacks event](./38111-bc-high-attackers-can-send-a-very-large-event-in-a-stacks-block-so-that-the-signer-can-never-g.md)
+* [38398 - [BC - High] Malicious Signers can initiate repeated contract calls to cause the multi-sign wallet to lose tx fee](./38398-bc-high-malicious-signers-can-initiate-repeated-contract-calls-to-cause-the-multi-sign-wallet.md)
+* [37479 - [BC - High] A single signer can lock users' funds by not notifying other signers of the executed \`sweep\` transaction](./37479-bc-high-a-single-signer-can-lock-users-funds-by-not-notifying-other-signers-of-the-executed-sw.md)
+* [38516 - [BC - High] Signer can censor transactions and halt the network by providing an invalid nonce or too many nonces](./38516-bc-high-signer-can-censor-transactions-and-halt-the-network-by-providing-an-invalid-nonce-or-t.md)
 
 </details>
 
@@ -34,14 +35,14 @@
 
 <summary>Medium</summary>
 
-* \#37777 \[BC-Medium] \`Emily.create\_deposit\` can overwrite any deposit to the Pending state
-* \#38133 \[BC-Medium] A rogue Signer can censor any deposit request from being processed and fullfilled on the Stacks blockchain
-* \#37384 \[BC-Medium] Attacker can front-run call to emily api with incorrect data, preventing legit user from registering their deposit
-* \#38551 \[BC-Medium] A signer can request stacks tx nonces in batches in advance and then DoS other signers' sBTC contract calls
-* \#37470 \[BC-Medium] SBTC Signers do not page through pending deposit requests making it trivially easy to block legit deposits by spamming Emily API
-* \#38270 \[BC-Medium] A signer can send a large number of junk \`WstsNetMessage::NonceRequest\` through P2P to make other signers run out of memory
-* \#38003 \[BC-Medium] A malicious coordinator calling \`Emily::update\_deposits\` can make the entire Signers network inoperable
-* \#37545 \[BC-Medium] Deposits with a lock\_time of 16 cannot be processed
+* [37777 - [BC - Medium] \`Emily.create\_deposit\` can overwrite any deposit to the Pending state](./37777-bc-medium-emily.create_deposit-can-overwrite-any-deposit-to-the-pending-state.md)
+* [38133 - [BC - Medium] A rogue Signer can censor any deposit request from being processed and fullfilled on the Stacks blockchain](./38133-bc-medium-a-rogue-signer-can-censor-any-deposit-request-from-being-processed-and-fullfilled-on.md)
+* [37384 - [BC - Medium] Attacker can front-run call to emily api with incorrect data, preventing legit user from registering their deposit](./37384-bc-medium-attacker-can-front-run-call-to-emily-api-with-incorrect-data-preventing-legit-user-f.md)
+* [38551 - [BC - Medium] A signer can request stacks tx nonces in batches in advance and then DoS other signers' sBTC contract calls](./38551-bc-medium-a-signer-can-request-stacks-tx-nonces-in-batches-in-advance-and-then-dos-other-signe.md)
+* [37470 - [BC - Medium] SBTC Signers do not page through pending deposit requests making it trivially easy to block legit deposits by spamming Emily API](./37470-bc-medium-sbtc-signers-do-not-page-through-pending-deposit-requests-making-it-trivially-easy-t.md)
+* [38270 - [BC - Medium] A signer can send a large number of junk \`WstsNetMessage::NonceRequest\` through P2P to make other signers run out of memory](./38270-bc-medium-a-signer-can-send-a-large-number-of-junk-wstsnetmessage-noncerequest-through-p2p-to.md)
+* [38003 - [BC - Medium] A malicious coordinator calling \`Emily::update\_deposits\` can make the entire Signers network inoperable](./38003-bc-medium-a-malicious-coordinator-calling-emily-update_deposits-can-make-the-entire-signers-ne.md)
+* [37545 - [BC - Medium] Deposits with a lock\_time of 16 cannot be processed](./37545-bc-medium-deposits-with-a-lock_time-of-16-cannot-be-processed.md)
 
 </details>
 
@@ -49,10 +50,10 @@
 
 <summary>Low</summary>
 
-* \#38605 \[BC-Low] Lack of fee\_rate/last\_fees validation in handle\_bitcoin\_pre\_sign\_request ebables rogue signer to cause financial loss to depositors
-* \#38028 \[BC-Low] There is a Partial Network Degradation Due to DynamoDB GSI Throttling Under High Traffic
-* \#38460 \[BC-Low] The coordinator can set a higher BTC tx fee than the current network to make users to pay more fees to the BTC miner
-* \#37500 \[BC-Low] Blocklist can be circumvented due to incorrect blocking logic in \`request\_decider::can\_accept\_deposit\_request\`
+* [38605 - [BC - Low] Lack of fee\_rate/last\_fees validation in handle\_bitcoin\_pre\_sign\_request ebables rogue signer to cause financial loss to depositors](./38605-bc-low-lack-of-fee_rate-last_fees-validation-in-handle_bitcoin_pre_sign_request-ebables-rogue.md)
+* [38028 - [BC - Low] There is a Partial Network Degradation Due to DynamoDB GSI Throttling Under High Traffic](./38028-bc-low-there-is-a-partial-network-degradation-due-to-dynamodb-gsi-throttling-under-high-traffi.md)
+* [38460 - [BC - Low] The coordinator can set a higher BTC tx fee than the current network to make users to pay more fees to the BTC miner](./38460-bc-low-the-coordinator-can-set-a-higher-btc-tx-fee-than-the-current-network-to-make-users-to-p.md)
+* [37500 - [BC - Low] Blocklist can be circumvented due to incorrect blocking logic in \`request\_decider::can\_accept\_deposit\_request\`](./37500-bc-low-blocklist-can-be-circumvented-due-to-incorrect-blocking-logic-in-request_decider-can_ac.md)
 
 </details>
 
@@ -60,52 +61,53 @@
 
 <summary>Insight</summary>
 
-* \#38671 \[BC-Insight] Signer key rotation is not possible due to deadlock between submitting key rotation to Stacks and retrieving it
-* \#38030 \[BC-Insight] Coordinator can be crashed by signers on DKG
-* \#38223 \[BC-Insight] Attackers can disrupt the tag order of gossip messages to bypass signature verification
-* \#38690 \[BC-Insight] A malicious coordinator can run multiple DKG coordination in parallel and manipulate their order to break the signers network
-* \#38160 \[BC-Insight] Governance calling \`sbtc-registry.update-protocol-contract\` may cause Stacks' events to be ignored by the signer
-* \#37530 \[BC-Insight] Deposits can be completely DoSed due to incorrect transaction construction
+* [38671 - [BC - Insight] Signer key rotation is not possible due to deadlock between submitting key rotation to Stacks and retrieving it](./38671-bc-insight-signer-key-rotation-is-not-possible-due-to-deadlock-between-submitting-key-rotation.md)
+* [38030 - [BC - Insight] Coordinator can be crashed by signers on DKG](./38030-bc-insight-coordinator-can-be-crashed-by-signers-on-dkg.md)
+* [38223 - [BC - Insight] Attackers can disrupt the tag order of gossip messages to bypass signature verification](./38223-bc-insight-attackers-can-disrupt-the-tag-order-of-gossip-messages-to-bypass-signature-verifica.md)
+* [38690 - [BC - Insight] A malicious coordinator can run multiple DKG coordination in parallel and manipulate their order to break the signers network](./38690-bc-insight-a-malicious-coordinator-can-run-multiple-dkg-coordination-in-parallel-and-manipulat.md)
+* [38160 - [BC - Insight] Governance calling \`sbtc-registry.update-protocol-contract\` may cause Stacks' events to be ignored by the signer](./38160-bc-insight-governance-calling-sbtc-registry.update-protocol-contract-may-cause-stacks-events-t.md)
+* [37530 - [BC - Insight] Deposits can be completely DoSed due to incorrect transaction construction](./37530-bc-insight-deposits-can-be-completely-dosed-due-to-incorrect-transaction-construction.md)
 
 </details>
 
 ## Reports by Type
 
+[Blockchain/DLT](<README.md#blockchain-dlt>)
 <details>
 
 <summary>Blockchain/DLT</summary>
 
-* \#37718 \[BC-High] Key rotations bricks the system due to incorrect \`aggregate\_key\` being used to spend the \`peg UTXO\` when signing a sweep transaction
-* \#37777 \[BC-Medium] \`Emily.create\_deposit\` can overwrite any deposit to the Pending state
-* \#37811 \[BC-High] Missing length check when parsing \`SignatureShareRequest\` in the signers allows the coordinator to halt other signers, shutting down the network
-* \#37814 \[BC-High] Signers can crash other signers by sending an invalid \`DkgPrivateShares\` due to missing check before passing the payload to \`SignerStateMachine::process\`
-* \#38582 \[BC-High] The \`BitcoinCoreClient::get\_tx\_info\` does not support coinbase transactions, which may cause sBTC to be attacked by btc miners or sBTC donations to be lost
-* \#38605 \[BC-Low] Lack of fee\_rate/last\_fees validation in handle\_bitcoin\_pre\_sign\_request ebables rogue signer to cause financial loss to depositors
-* \#37861 \[BC-Critical] SBTC Signer WSTS implementation allows nonce replays such that a malicious signer can steal all funds
-* \#38392 \[BC-High] Signer can steal STX tokens in multi-sign wallet by setting a high stacks tx fee
-* \#38671 \[BC-Insight] Signer key rotation is not possible due to deadlock between submitting key rotation to Stacks and retrieving it
-* \#38458 \[BC-Critical] The coordinator can submit empty BTC transactions to drain BTC tokens in the multi-sign wallet
-* \#38028 \[BC-Low] There is a Partial Network Degradation Due to DynamoDB GSI Throttling Under High Traffic
-* \#38030 \[BC-Insight] Coordinator can be crashed by signers on DKG
-* \#38740 \[BC-High] The missing check in Deposits::DepositScriptInputs::parse() permits losing funds by sending them to an invalid principal
-* \#38053 \[BC-High] A single signer can continuously prevent signatures from being finalized, halting network operations
-* \#38133 \[BC-Medium] A rogue Signer can censor any deposit request from being processed and fullfilled on the Stacks blockchain
-* \#37384 \[BC-Medium] Attacker can front-run call to emily api with incorrect data, preventing legit user from registering their deposit
-* \#38460 \[BC-Low] The coordinator can set a higher BTC tx fee than the current network to make users to pay more fees to the BTC miner
-* \#38477 \[BC-High] A single signer can abort every attempted signing round by providing an invalid packet once the coordinator requests signature shares
-* \#38111 \[BC-High] Attackers can send a very large event in a Stacks block so that the Signer can never get the Stacks event
-* \#38551 \[BC-Medium] A signer can request stacks tx nonces in batches in advance and then DoS other signers' sBTC contract calls
-* \#37470 \[BC-Medium] SBTC Signers do not page through pending deposit requests making it trivially easy to block legit deposits by spamming Emily API
-* \#38223 \[BC-Insight] Attackers can disrupt the tag order of gossip messages to bypass signature verification
-* \#38270 \[BC-Medium] A signer can send a large number of junk \`WstsNetMessage::NonceRequest\` through P2P to make other signers run out of memory
-* \#38690 \[BC-Insight] A malicious coordinator can run multiple DKG coordination in parallel and manipulate their order to break the signers network
-* \#37500 \[BC-Low] Blocklist can be circumvented due to incorrect blocking logic in \`request\_decider::can\_accept\_deposit\_request\`
-* \#38160 \[BC-Insight] Governance calling \`sbtc-registry.update-protocol-contract\` may cause Stacks' events to be ignored by the signer
-* \#37530 \[BC-Insight] Deposits can be completely DoSed due to incorrect transaction construction
-* \#38398 \[BC-High] Malicious Signers can initiate repeated contract calls to cause the multi-sign wallet to lose tx fee
-* \#37479 \[BC-High] A single signer can lock users' funds by not notifying other signers of the executed \`sweep\` transaction
-* \#38003 \[BC-Medium] A malicious coordinator calling \`Emily::update\_deposits\` can make the entire Signers network inoperable
-* \#37545 \[BC-Medium] Deposits with a lock\_time of 16 cannot be processed
-* \#38516 \[BC-High] Signer can censor transactions and halt the network by providing an invalid nonce or too many nonces
+* [37718 - [BC - High] Key rotations bricks the system due to incorrect \`aggregate\_key\` being used to spend the \`peg UTXO\` when signing a sweep transaction](./37718-bc-high-key-rotations-bricks-the-system-due-to-incorrect-aggregate_key-being-used-to-spend-the.md)
+* [37777 - [BC - Medium] \`Emily.create\_deposit\` can overwrite any deposit to the Pending state](./37777-bc-medium-emily.create_deposit-can-overwrite-any-deposit-to-the-pending-state.md)
+* [37811 - [BC - High] Missing length check when parsing \`SignatureShareRequest\` in the signers allows the coordinator to halt other signers, shutting down the network](./37811-bc-high-missing-length-check-when-parsing-signaturesharerequest-in-the-signers-allows-the-coor.md)
+* [37814 - [BC - High] Signers can crash other signers by sending an invalid \`DkgPrivateShares\` due to missing check before passing the payload to \`SignerStateMachine::process\`](./37814-bc-high-signers-can-crash-other-signers-by-sending-an-invalid-dkgprivateshares-due-to-missing.md)
+* [38582 - [BC - High] The \`BitcoinCoreClient::get\_tx\_info\` does not support coinbase transactions, which may cause sBTC to be attacked by btc miners or sBTC donations to be lost](./38582-bc-high-the-bitcoincoreclient-get_tx_info-does-not-support-coinbase-transactions-which-may-cau.md)
+* [38605 - [BC - Low] Lack of fee\_rate/last\_fees validation in handle\_bitcoin\_pre\_sign\_request ebables rogue signer to cause financial loss to depositors](./38605-bc-low-lack-of-fee_rate-last_fees-validation-in-handle_bitcoin_pre_sign_request-ebables-rogue.md)
+* [37861 - [BC - Critical] SBTC Signer WSTS implementation allows nonce replays such that a malicious signer can steal all funds](./37861-bc-critical-sbtc-signer-wsts-implementation-allows-nonce-replays-such-that-a-malicious-signer.md)
+* [38392 - [BC - High] Signer can steal STX tokens in multi-sign wallet by setting a high stacks tx fee](./38392-bc-high-signer-can-steal-stx-tokens-in-multi-sign-wallet-by-setting-a-high-stacks-tx-fee.md)
+* [38671 - [BC - Insight] Signer key rotation is not possible due to deadlock between submitting key rotation to Stacks and retrieving it](./38671-bc-insight-signer-key-rotation-is-not-possible-due-to-deadlock-between-submitting-key-rotation.md)
+* [38458 - [BC - Critical] The coordinator can submit empty BTC transactions to drain BTC tokens in the multi-sign wallet](./38458-bc-critical-the-coordinator-can-submit-empty-btc-transactions-to-drain-btc-tokens-in-the-multi.md)
+* [38028 - [BC - Low] There is a Partial Network Degradation Due to DynamoDB GSI Throttling Under High Traffic](./38028-bc-low-there-is-a-partial-network-degradation-due-to-dynamodb-gsi-throttling-under-high-traffi.md)
+* [38030 - [BC - Insight] Coordinator can be crashed by signers on DKG](./38030-bc-insight-coordinator-can-be-crashed-by-signers-on-dkg.md)
+* [38740 - [BC - High] The missing check in Deposits::DepositScriptInputs::parse() permits losing funds by sending them to an invalid principal](./38740-bc-high-the-missing-check-in-deposits-depositscriptinputs-parse-permits-losing-funds-by-sendin.md)
+* [38053 - [BC - High] A single signer can continuously prevent signatures from being finalized, halting network operations](./38053-bc-high-a-single-signer-can-continuously-prevent-signatures-from-being-finalized-halting-netwo.md)
+* [38133 - [BC - Medium] A rogue Signer can censor any deposit request from being processed and fullfilled on the Stacks blockchain](./38133-bc-medium-a-rogue-signer-can-censor-any-deposit-request-from-being-processed-and-fullfilled-on.md)
+* [37384 - [BC - Medium] Attacker can front-run call to emily api with incorrect data, preventing legit user from registering their deposit](./37384-bc-medium-attacker-can-front-run-call-to-emily-api-with-incorrect-data-preventing-legit-user-f.md)
+* [38460 - [BC - Low] The coordinator can set a higher BTC tx fee than the current network to make users to pay more fees to the BTC miner](./38460-bc-low-the-coordinator-can-set-a-higher-btc-tx-fee-than-the-current-network-to-make-users-to-p.md)
+* [38477 - [BC - High] A single signer can abort every attempted signing round by providing an invalid packet once the coordinator requests signature shares](./38477-bc-high-a-single-signer-can-abort-every-attempted-signing-round-by-providing-an-invalid-packet.md)
+* [38111 - [BC - High] Attackers can send a very large event in a Stacks block so that the Signer can never get the Stacks event](./38111-bc-high-attackers-can-send-a-very-large-event-in-a-stacks-block-so-that-the-signer-can-never-g.md)
+* [38551 - [BC - Medium] A signer can request stacks tx nonces in batches in advance and then DoS other signers' sBTC contract calls](./38551-bc-medium-a-signer-can-request-stacks-tx-nonces-in-batches-in-advance-and-then-dos-other-signe.md)
+* [37470 - [BC - Medium] SBTC Signers do not page through pending deposit requests making it trivially easy to block legit deposits by spamming Emily API](./37470-bc-medium-sbtc-signers-do-not-page-through-pending-deposit-requests-making-it-trivially-easy-t.md)
+* [38223 - [BC - Insight] Attackers can disrupt the tag order of gossip messages to bypass signature verification](./38223-bc-insight-attackers-can-disrupt-the-tag-order-of-gossip-messages-to-bypass-signature-verifica.md)
+* [38270 - [BC - Medium] A signer can send a large number of junk \`WstsNetMessage::NonceRequest\` through P2P to make other signers run out of memory](./38270-bc-medium-a-signer-can-send-a-large-number-of-junk-wstsnetmessage-noncerequest-through-p2p-to.md)
+* [38690 - [BC - Insight] A malicious coordinator can run multiple DKG coordination in parallel and manipulate their order to break the signers network](./38690-bc-insight-a-malicious-coordinator-can-run-multiple-dkg-coordination-in-parallel-and-manipulat.md)
+* [37500 - [BC - Low] Blocklist can be circumvented due to incorrect blocking logic in \`request\_decider::can\_accept\_deposit\_request\`](./37500-bc-low-blocklist-can-be-circumvented-due-to-incorrect-blocking-logic-in-request_decider-can_ac.md)
+* [38160 - [BC - Insight] Governance calling \`sbtc-registry.update-protocol-contract\` may cause Stacks' events to be ignored by the signer](./38160-bc-insight-governance-calling-sbtc-registry.update-protocol-contract-may-cause-stacks-events-t.md)
+* [37530 - [BC - Insight] Deposits can be completely DoSed due to incorrect transaction construction](./37530-bc-insight-deposits-can-be-completely-dosed-due-to-incorrect-transaction-construction.md)
+* [38398 - [BC - High] Malicious Signers can initiate repeated contract calls to cause the multi-sign wallet to lose tx fee](./38398-bc-high-malicious-signers-can-initiate-repeated-contract-calls-to-cause-the-multi-sign-wallet.md)
+* [37479 - [BC - High] A single signer can lock users' funds by not notifying other signers of the executed \`sweep\` transaction](./37479-bc-high-a-single-signer-can-lock-users-funds-by-not-notifying-other-signers-of-the-executed-sw.md)
+* [38003 - [BC - Medium] A malicious coordinator calling \`Emily::update\_deposits\` can make the entire Signers network inoperable](./38003-bc-medium-a-malicious-coordinator-calling-emily-update_deposits-can-make-the-entire-signers-ne.md)
+* [37545 - [BC - Medium] Deposits with a lock\_time of 16 cannot be processed](./37545-bc-medium-deposits-with-a-lock_time-of-16-cannot-be-processed.md)
+* [38516 - [BC - High] Signer can censor transactions and halt the network by providing an invalid nonce or too many nonces](./38516-bc-high-signer-can-censor-transactions-and-halt-the-network-by-providing-an-invalid-nonce-or-t.md)
 
 </details>

--- a/swaylend-frontend/README.md
+++ b/swaylend-frontend/README.md
@@ -2,22 +2,24 @@
 
 ## Reports by Severity
 
+[Insight](<README.md#insight>)
 <details>
 
 <summary>Insight</summary>
 
-* \#37196 \[W\&A-Insight] DOS due to Misleading 'CircularProgressBar' Display Due to Rounding of 'supplyUsed"
-* \#37822 \[W\&A-Insight] Incorrect Amounts Displayed To Foreign Users
+* [37196 - [W\&A - Insight] DOS due to Misleading 'CircularProgressBar' Display Due to Rounding of 'supplyUsed"](./37196-w-and-a-insight-dos-due-to-misleading-circularprogressbar-display-due-to-rounding-of-supplyuse.md)
+* [37822 - [W\&A - Insight] Incorrect Amounts Displayed To Foreign Users](./37822-w-and-a-insight-insight-incorrect-amounts-displayed-to-foreign-users.md)
 
 </details>
 
 ## Reports by Type
 
+[Websites &#x26; Applications](<README.md#websites-applications>)
 <details>
 
 <summary>Websites &#x26; Applications</summary>
 
-* \#37196 \[W\&A-Insight] DOS due to Misleading 'CircularProgressBar' Display Due to Rounding of 'supplyUsed"
-* \#37822 \[W\&A-Insight] Incorrect Amounts Displayed To Foreign Users
+* [37196 - [W\&A - Insight] DOS due to Misleading 'CircularProgressBar' Display Due to Rounding of 'supplyUsed"](./37196-w-and-a-insight-dos-due-to-misleading-circularprogressbar-display-due-to-rounding-of-supplyuse.md)
+* [37822 - [W\&A - Insight] Incorrect Amounts Displayed To Foreign Users](./37822-w-and-a-insight-insight-incorrect-amounts-displayed-to-foreign-users.md)
 
 </details>

--- a/swaylend_iop/README.md
+++ b/swaylend_iop/README.md
@@ -2,13 +2,14 @@
 
 ## Reports by Severity
 
+[Critical](<README.md#critical>) | [High](<README.md#high>) | [Medium](<README.md#medium>) | [Low](<README.md#low>) | [Insight](<README.md#insight>)
 <details>
 
 <summary>Critical</summary>
 
-* \#35767 \[SC-Critical] constanct value is used to check \`price.confidence\`
-* \#35758 \[SC-Critical] Loss of yield to the protocol due to incorrect interest rate applied
-* \#35684 \[SC-Critical] Incorrect Pyth Oracle Price Feed Process Leads to Wrong Collateral Value Calculation
+* [35767 - [SC - Critical] constanct value is used to check \`price.confidence\`](./35767-sc-critical-constanct-value-is-used-to-check-price.confidence.md)
+* [35758 - [SC - Critical] Loss of yield to the protocol due to incorrect interest rate applied](./35758-sc-critical-loss-of-yield-to-the-protocol-due-to-incorrect-interest-rate-applied.md)
+* [35684 - [SC - Critical] Incorrect Pyth Oracle Price Feed Process Leads to Wrong Collateral Value Calculation](./35684-sc-critical-incorrect-pyth-oracle-price-feed-process-leads-to-wrong-collateral-value-calculati.md)
 
 </details>
 
@@ -16,11 +17,11 @@
 
 <summary>High</summary>
 
-* \#35793 \[SC-High] \`src-20.burn\` should use "==" instead of ">="
-* \#35876 \[SC-High] Users will lose funds on calls to critical functions if the prices are not updated
-* \#35750 \[SC-High] User loss due to Pyth oracle update fee being smaller than the msg amount sent
-* \#36117 \[SC-High] Permanent freezing of tokens when user sends extra tokens as update fee
-* \#35831 \[SC-High] By bypassing base\_borrow\_min limitation borrows can create inabsorbable loans
+* [35793 - [SC - High] \`src-20.burn\` should use "==" instead of ">="](./35793-sc-high-src-20.burn-should-use-instead-of-greater-than.md)
+* [35876 - [SC - High] Users will lose funds on calls to critical functions if the prices are not updated](./35876-sc-high-users-will-lose-funds-on-calls-to-critical-functions-if-the-prices-are-not-updated.md)
+* [35750 - [SC - High] User loss due to Pyth oracle update fee being smaller than the msg amount sent](./35750-sc-high-user-loss-due-to-pyth-oracle-update-fee-being-smaller-than-the-msg-amount-sent.md)
+* [36117 - [SC - High] Permanent freezing of tokens when user sends extra tokens as update fee](./36117-sc-high-permanent-freezing-of-tokens-when-user-sends-extra-tokens-as-update-fee.md)
+* [35831 - [SC - High] By bypassing base\_borrow\_min limitation borrows can create inabsorbable loans](./35831-sc-high-by-bypassing-base_borrow_min-limitation-borrows-can-create-inabsorbable-loans.md)
 
 </details>
 
@@ -28,10 +29,10 @@
 
 <summary>Medium</summary>
 
-* \#35815 \[SC-Medium] \`Market.present\_value\_borrow\` should be roundUp
-* \#36137 \[SC-Medium] \`absorb\_internal\` might be DOSed
-* \#36034 \[SC-Medium] truncation in the \`present\_value\_borrow()\` can lead to loss of accrued borrow interests.
-* \#35853 \[SC-Medium] permissonless constructor always for front-running owner initialization.
+* [35815 - [SC - Medium] \`Market.present\_value\_borrow\` should be roundUp](./35815-sc-medium-market.present_value_borrow-should-be-roundup.md)
+* [36137 - [SC - Medium] \`absorb\_internal\` might be DOSed](./36137-sc-medium-absorb_internal-might-be-dosed.md)
+* [36034 - [SC - Medium] truncation in the \`present\_value\_borrow()\` can lead to loss of accrued borrow interests.](./36034-sc-medium-truncation-in-the-present_value_borrow-can-lead-to-loss-of-accrued-borrow-interests..m)
+* [35853 - [SC - Medium] permissonless constructor always for front-running owner initialization.](./35853-sc-medium-permissonless-constructor-always-for-front-running-owner-initialization..m)
 
 </details>
 
@@ -39,12 +40,12 @@
 
 <summary>Low</summary>
 
-* \#35761 \[SC-Low] Unhandled smaller base decimals than 6 or bigger than the collateral's decimals
-* \#35760 \[SC-Low] \`market::available\_to\_borrow()\` compares the collateral in USD against the borrow in base units
-* \#35724 \[SC-Low] Users can withdraw collateral even when the admin pauses the contract.
-* \#36158 \[SC-Low] \`Market.collateral\_value\_to\_sell\` will always revert if collateral\_configuration.decimals < storage.market\_configuration.base\_token\_decimals
-* \#35908 \[SC-Low] If the collateral token''s decimal is <= the base token decimal in a market, \`collateral\_value\_to\_sell()\` will always revert & \`available\_to\_borrow()\` will return a wrong amount tha...
-* \#35732 \[SC-Low] Withdrawals can not be paused which could lead to protocol insolvency in case of issues
+* [35761 - [SC - Low] Unhandled smaller base decimals than 6 or bigger than the collateral's decimals](./35761-sc-low-unhandled-smaller-base-decimals-than-6-or-bigger-than-the-collaterals-decimals.md)
+* [35760 - [SC - Low] \`market::available\_to\_borrow()\` compares the collateral in USD against the borrow in base units](./35760-sc-low-market-available_to_borrow-compares-the-collateral-in-usd-against-the-borrow-in-base-un.md)
+* [35724 - [SC - Low] Users can withdraw collateral even when the admin pauses the contract.](./35724-sc-low-users-can-withdraw-collateral-even-when-the-admin-pauses-the-contract..md)
+* [36158 - [SC - Low] \`Market.collateral\_value\_to\_sell\` will always revert if collateral\_configuration.decimals < storage.market\_configuration.base\_token\_decimals](./36158-sc-low-market.collateral_value_to_sell-will-always-revert-if-collateral_configuration.md)
+* [35908 - [SC - Low] If the collateral token''s decimal is <= the base token decimal in a market, \`collateral\_value\_to\_sell()\` will always revert & \`available\_to\_borrow()\` will return a wrong amount tha...](./35908-sc-low-if-the-collateral-token-s-decimal-is-less-than-the-base-token-decimal-in-a-market-colla.md)
+* [35732 - [SC - Low] Withdrawals can not be paused which could lead to protocol insolvency in case of issues](./35732-sc-low-withdrawals-can-not-be-paused-which-could-lead-to-protocol-insolvency-in-case-of-issues.md)
 
 </details>
 
@@ -52,46 +53,47 @@
 
 <summary>Insight</summary>
 
-* \#35708 \[SC-Insight] Adding too many collaterals will halt the protocol operation
-* \#35999 \[SC-Insight] Incorrect event name
-* \#35794 \[SC-Insight] \`Market.absorb\` can be called when \`Market.supply\_collateral\` is paused
-* \#36065 \[SC-Insight] \`Market.update\_market\_configuration\` should reuse old configuration's \`base\_token.decimals\`
-* \#36108 \[SC-Insight] \`recipient\` with a NULL address will lead to permanent loss of minted coins
-* \#36138 \[SC-Insight] \`Market.update\_collateral\_asset\` should reuse old configuration's \`asset\_id\`
-* \#35768 \[SC-Insight] \`Market.set\_pyth\_contract\_id\` should emit an event
+* [35708 - [SC - Insight] Adding too many collaterals will halt the protocol operation](./35708-sc-insight-adding-too-many-collaterals-will-halt-the-protocol-operation.md)
+* [35999 - [SC - Insight] Incorrect event name](./35999-sc-insight-incorrect-event-name.md)
+* [35794 - [SC - Insight] \`Market.absorb\` can be called when \`Market.supply\_collateral\` is paused](./35794-sc-insight-market.absorb-can-be-called-when-market.supply_collateral-is-paused.md)
+* [36065 - [SC - Insight] \`Market.update\_market\_configuration\` should reuse old configuration's \`base\_token.decimals\`](./36065-sc-insight-market.update_market_configuration-should-reuse-old-configurations-base_token.decim.md)
+* [36108 - [SC - Insight] \`recipient\` with a NULL address will lead to permanent loss of minted coins](./36108-sc-insight-recipient-with-a-null-address-will-lead-to-permanent-loss-of-minted-coins.md)
+* [36138 - [SC - Insight] \`Market.update\_collateral\_asset\` should reuse old configuration's \`asset\_id\`](./36138-sc-insight-market.update_collateral_asset-should-reuse-old-configurations-asset_id.md)
+* [35768 - [SC - Insight] \`Market.set\_pyth\_contract\_id\` should emit an event](./35768-sc-insight-market.set_pyth_contract_id-should-emit-an-event.md)
 
 </details>
 
 ## Reports by Type
 
+[Smart Contract](<README.md#smart-contract>)
 <details>
 
 <summary>Smart Contract</summary>
 
-* \#35708 \[SC-Insight] Adding too many collaterals will halt the protocol operation
-* \#35761 \[SC-Low] Unhandled smaller base decimals than 6 or bigger than the collateral's decimals
-* \#35793 \[SC-High] \`src-20.burn\` should use "==" instead of ">="
-* \#35876 \[SC-High] Users will lose funds on calls to critical functions if the prices are not updated
-* \#35767 \[SC-Critical] constanct value is used to check \`price.confidence\`
-* \#35750 \[SC-High] User loss due to Pyth oracle update fee being smaller than the msg amount sent
-* \#35999 \[SC-Insight] Incorrect event name
-* \#35794 \[SC-Insight] \`Market.absorb\` can be called when \`Market.supply\_collateral\` is paused
-* \#35758 \[SC-Critical] Loss of yield to the protocol due to incorrect interest rate applied
-* \#35760 \[SC-Low] \`market::available\_to\_borrow()\` compares the collateral in USD against the borrow in base units
-* \#35815 \[SC-Medium] \`Market.present\_value\_borrow\` should be roundUp
-* \#35724 \[SC-Low] Users can withdraw collateral even when the admin pauses the contract.
-* \#36065 \[SC-Insight] \`Market.update\_market\_configuration\` should reuse old configuration's \`base\_token.decimals\`
-* \#36108 \[SC-Insight] \`recipient\` with a NULL address will lead to permanent loss of minted coins
-* \#36117 \[SC-High] Permanent freezing of tokens when user sends extra tokens as update fee
-* \#36137 \[SC-Medium] \`absorb\_internal\` might be DOSed
-* \#36138 \[SC-Insight] \`Market.update\_collateral\_asset\` should reuse old configuration's \`asset\_id\`
-* \#36158 \[SC-Low] \`Market.collateral\_value\_to\_sell\` will always revert if collateral\_configuration.decimals < storage.market\_configuration.base\_token\_decimals
-* \#35831 \[SC-High] By bypassing base\_borrow\_min limitation borrows can create inabsorbable loans
-* \#35684 \[SC-Critical] Incorrect Pyth Oracle Price Feed Process Leads to Wrong Collateral Value Calculation
-* \#35768 \[SC-Insight] \`Market.set\_pyth\_contract\_id\` should emit an event
-* \#35908 \[SC-Low] If the collateral token''s decimal is <= the base token decimal in a market, \`collateral\_value\_to\_sell()\` will always revert & \`available\_to\_borrow()\` will return a wrong amount tha...
-* \#35732 \[SC-Low] Withdrawals can not be paused which could lead to protocol insolvency in case of issues
-* \#36034 \[SC-Medium] truncation in the \`present\_value\_borrow()\` can lead to loss of accrued borrow interests.
-* \#35853 \[SC-Medium] permissonless constructor always for front-running owner initialization.
+* [35708 - [SC - Insight] Adding too many collaterals will halt the protocol operation](./35708-sc-insight-adding-too-many-collaterals-will-halt-the-protocol-operation.md)
+* [35761 - [SC - Low] Unhandled smaller base decimals than 6 or bigger than the collateral's decimals](./35761-sc-low-unhandled-smaller-base-decimals-than-6-or-bigger-than-the-collaterals-decimals.md)
+* [35793 - [SC - High] \`src-20.burn\` should use "==" instead of ">="](./35793-sc-high-src-20.burn-should-use-instead-of-greater-than.md)
+* [35876 - [SC - High] Users will lose funds on calls to critical functions if the prices are not updated](./35876-sc-high-users-will-lose-funds-on-calls-to-critical-functions-if-the-prices-are-not-updated.md)
+* [35767 - [SC - Critical] constanct value is used to check \`price.confidence\`](./35767-sc-critical-constanct-value-is-used-to-check-price.confidence.md)
+* [35750 - [SC - High] User loss due to Pyth oracle update fee being smaller than the msg amount sent](./35750-sc-high-user-loss-due-to-pyth-oracle-update-fee-being-smaller-than-the-msg-amount-sent.md)
+* [35999 - [SC - Insight] Incorrect event name](./35999-sc-insight-incorrect-event-name.md)
+* [35794 - [SC - Insight] \`Market.absorb\` can be called when \`Market.supply\_collateral\` is paused](./35794-sc-insight-market.absorb-can-be-called-when-market.supply_collateral-is-paused.md)
+* [35758 - [SC - Critical] Loss of yield to the protocol due to incorrect interest rate applied](./35758-sc-critical-loss-of-yield-to-the-protocol-due-to-incorrect-interest-rate-applied.md)
+* [35760 - [SC - Low] \`market::available\_to\_borrow()\` compares the collateral in USD against the borrow in base units](./35760-sc-low-market-available_to_borrow-compares-the-collateral-in-usd-against-the-borrow-in-base-un.md)
+* [35815 - [SC - Medium] \`Market.present\_value\_borrow\` should be roundUp](./35815-sc-medium-market.present_value_borrow-should-be-roundup.md)
+* [35724 - [SC - Low] Users can withdraw collateral even when the admin pauses the contract.](./35724-sc-low-users-can-withdraw-collateral-even-when-the-admin-pauses-the-contract..md)
+* [36065 - [SC - Insight] \`Market.update\_market\_configuration\` should reuse old configuration's \`base\_token.decimals\`](./36065-sc-insight-market.update_market_configuration-should-reuse-old-configurations-base_token.decim.md)
+* [36108 - [SC - Insight] \`recipient\` with a NULL address will lead to permanent loss of minted coins](./36108-sc-insight-recipient-with-a-null-address-will-lead-to-permanent-loss-of-minted-coins.md)
+* [36117 - [SC - High] Permanent freezing of tokens when user sends extra tokens as update fee](./36117-sc-high-permanent-freezing-of-tokens-when-user-sends-extra-tokens-as-update-fee.md)
+* [36137 - [SC - Medium] \`absorb\_internal\` might be DOSed](./36137-sc-medium-absorb_internal-might-be-dosed.md)
+* [36138 - [SC - Insight] \`Market.update\_collateral\_asset\` should reuse old configuration's \`asset\_id\`](./36138-sc-insight-market.update_collateral_asset-should-reuse-old-configurations-asset_id.md)
+* [36158 - [SC - Low] \`Market.collateral\_value\_to\_sell\` will always revert if collateral\_configuration.decimals < storage.market\_configuration.base\_token\_decimals](./36158-sc-low-market.collateral_value_to_sell-will-always-revert-if-collateral_configuration.md)
+* [35831 - [SC - High] By bypassing base\_borrow\_min limitation borrows can create inabsorbable loans](./35831-sc-high-by-bypassing-base_borrow_min-limitation-borrows-can-create-inabsorbable-loans.md)
+* [35684 - [SC - Critical] Incorrect Pyth Oracle Price Feed Process Leads to Wrong Collateral Value Calculation](./35684-sc-critical-incorrect-pyth-oracle-price-feed-process-leads-to-wrong-collateral-value-calculati.md)
+* [35768 - [SC - Insight] \`Market.set\_pyth\_contract\_id\` should emit an event](./35768-sc-insight-market.set_pyth_contract_id-should-emit-an-event.md)
+* [35908 - [SC - Low] If the collateral token''s decimal is <= the base token decimal in a market, \`collateral\_value\_to\_sell()\` will always revert & \`available\_to\_borrow()\` will return a wrong amount tha...](./35908-sc-low-if-the-collateral-token-s-decimal-is-less-than-the-base-token-decimal-in-a-market-colla.md)
+* [35732 - [SC - Low] Withdrawals can not be paused which could lead to protocol insolvency in case of issues](./35732-sc-low-withdrawals-can-not-be-paused-which-could-lead-to-protocol-insolvency-in-case-of-issues.md)
+* [36034 - [SC - Medium] truncation in the \`present\_value\_borrow()\` can lead to loss of accrued borrow interests.](./36034-sc-medium-truncation-in-the-present_value_borrow-can-lead-to-loss-of-accrued-borrow-interests..m)
+* [35853 - [SC - Medium] permissonless constructor always for front-running owner initialization.](./35853-sc-medium-permissonless-constructor-always-for-front-running-owner-initialization..m)
 
 </details>

--- a/zano-iop/README.md
+++ b/zano-iop/README.md
@@ -2,11 +2,12 @@
 
 ## Reports by Severity
 
+[High](<README.md#high>) | [Insight](<README.md#insight>)
 <details>
 
 <summary>High</summary>
 
-* \#40530 \[W\&A-High] JWT Salt Expiration isn't entirely correct in wallet\_rpc\_server::auth\_http\_request
+* [40530 - [W\&A - High] JWT Salt Expiration isn't entirely correct in wallet\_rpc\_server::auth\_http\_request](./40530-w-and-a-high-jwt-salt-expiration-isnt-entirely-correct-in-wallet_rpc_server-auth_http_request.md)
 
 </details>
 
@@ -14,30 +15,32 @@
 
 <summary>Insight</summary>
 
-* \#40794 \[W\&A-Insight] Unsecured Wallet Voting Configuration Allows Unauthorized Vote Manipulation Despite Password Protection
-* \#40970 \[BC-Insight] Double spending by using 0-point stealth address and signature elements in CLSAG-GGX proof verification
-* \#40990 \[BC-Insight] Security best practices
-* \#41027 \[BC-Insight] Breaking asset surjection proof assumptions
+* [40794 - [W\&A - Insight] Unsecured Wallet Voting Configuration Allows Unauthorized Vote Manipulation Despite Password Protection](./40794-w-and-a-insight-unsecured-wallet-voting-configuration-allows-unauthorized-vote-manipulation-de.md)
+* [40970 - [BC - Insight] Double spending by using 0-point stealth address and signature elements in CLSAG-GGX proof verification](./40970-bc-insight-double-spending-by-using-0-point-stealth-address-and-signature-elements-in-clsag-gg.md)
+* [40990 - [BC - Insight] Security best practices](./40990-bc-insight-security-best-practices.md)
+* [41027 - [BC - Insight] Breaking asset surjection proof assumptions](./41027-bc-insight-breaking-asset-surjection-proof-assumptions.md)
 
 </details>
 
 ## Reports by Type
 
+[Blockchain/DLT](<README.md#blockchain-dlt>)
 <details>
 
 <summary>Blockchain/DLT</summary>
 
-* \#40970 \[BC-Insight] Double spending by using 0-point stealth address and signature elements in CLSAG-GGX proof verification
-* \#40990 \[BC-Insight] Security best practices
-* \#41027 \[BC-Insight] Breaking asset surjection proof assumptions
+* [40970 - [BC - Insight] Double spending by using 0-point stealth address and signature elements in CLSAG-GGX proof verification](./40970-bc-insight-double-spending-by-using-0-point-stealth-address-and-signature-elements-in-clsag-gg.md)
+* [40990 - [BC - Insight] Security best practices](./40990-bc-insight-security-best-practices.md)
+* [41027 - [BC - Insight] Breaking asset surjection proof assumptions](./41027-bc-insight-breaking-asset-surjection-proof-assumptions.md)
 
 </details>
 
+[Websites &#x26; Applications](<README.md#websites-applications>)
 <details>
 
 <summary>Websites &#x26; Applications</summary>
 
-* \#40794 \[W\&A-Insight] Unsecured Wallet Voting Configuration Allows Unauthorized Vote Manipulation Despite Password Protection
-* \#40530 \[W\&A-High] JWT Salt Expiration isn't entirely correct in wallet\_rpc\_server::auth\_http\_request
+* [40794 - [W\&A - Insight] Unsecured Wallet Voting Configuration Allows Unauthorized Vote Manipulation Despite Password Protection](./40794-w-and-a-insight-unsecured-wallet-voting-configuration-allows-unauthorized-vote-manipulation-de.md)
+* [40530 - [W\&A - High] JWT Salt Expiration isn't entirely correct in wallet\_rpc\_server::auth\_http\_request](./40530-w-and-a-high-jwt-salt-expiration-isnt-entirely-correct-in-wallet_rpc_server-auth_http_request.md)
 
 </details>


### PR DESCRIPTION
This PR updates all audit README.md files to include missing redirects.

Previously, some audit READMEs had links redirecting to their main README, while others did not.
This change makes the structure consistent across all audits.

Changes

Added missing redirects in all audit README.md files

Ensured uniform navigation between audit reports

Motivation

Consistency in documentation helps contributors and researchers navigate audit reports more easily, reducing confusion and improving usability.

Notes

In the ethereum-protocol-attackaton, reports 37113 and 38459 are listed in the README, but their corresponding report files are missing.